### PR TITLE
feat: [#48] Enable govulncheck and enforce minimum code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 
 | option                             | default |
 | ---------------------------------- | ------- |
+| code_coverage_expected             | 80      |
 | golang-unit-tests-exclusions       | ' '     |
 | golangci-lint-version              | v1.55.2 |
 | golang-number-of-tests-in-parallel | 4       |

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ runs:
       shell: bash
       run: |
         go mod verify
+    - uses: golang/govulncheck-action@v1.0.3
+      with:
+        go-version-file: go.mod
+        go-package: ./...
     #
     # Check for 'incorrect import order', let pipeline fail if true and provide
     # instruction to remediate it. Note: check is included in golangci-lint,

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@ name: mcvs-golang-action
 description: |
   The Mission Critical Vulnerability Scanner (MCVS) Golang action.
 inputs:
+  code_coverage_expected:
+    description: |
+      The minimum code coverage.
+    default: "80"
   golang-unit-tests-exclusions:
     description: |
       The Golang paths that should be excluded from unit testing.
@@ -91,6 +95,18 @@ runs:
     #
     # Unit tests.
     #
+    - name: code coverage
+      shell: bash
+      run: |
+        go test -v -coverpkg=./... -coverprofile=profile.cov ./...
+        code_coverage_actual=$(go tool cover -func profile.cov |\
+          grep total: |\
+          awk '{print $3}' |\
+          sed 's/%//')
+        if (( $(echo "${{ inputs.code_coverage_expected }} > ${code_coverage_actual}" | bc -l) )); then
+          echo "The actual code coverage: '${code_coverage_actual}' is too low. Expected: '${{ inputs.code_coverage_expected }}'."
+          exit 1
+        fi
     - name: unit tests
       shell: bash
       run: |


### PR DESCRIPTION
* Enable govulncheck to check Golang vulnerabilities.
* Enforce a minimum code coverage. By default: 80 percent.