### PR TITLE
fix: [#89] Ensure that yamllint allows 1 space before a comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
     #
     - run: |
         pip install --user yamllint==1.35.1
-        yamllint .
+        yamllint -d '{extends: default, rules: {comments: {min-spaces-from-content: 1}}}' .
       shell: bash
     #
     # Install the golang version that has been defined in the go.mod file.


### PR DESCRIPTION
* Ensure that 1 space is required before a comment in YAML as it conflicts with prettier (see coupled issue).