### PR TITLE
fix: Allow use of GITHUB token for component test

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,8 @@ runs:
     #
     - name: component tests
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         ${GITHUB_ACTION_PATH}/src/go-test.sh \
           "" \


### PR DESCRIPTION
* It could be possible that a component test need to download docker images from a private registry.