### PR TITLE
fix: [#98] Golang version warning occurs due to missing if statement in govulncheck-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,7 @@ runs:
       run: |
         go mod verify
     - uses: golang/govulncheck-action@v1.0.4
+      if: inputs.testing-type == 'security-golang-modules'
       with:
         go-version-file: go.mod
         go-package: ./...


### PR DESCRIPTION
Golang version warning occurs due to missing if statement in govulncheck-action