### PR TITLE
feat: [#111] Allow consumers of this action to install gqlgenc version v0.25.4

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,7 @@ vars:
       else
         nproc
       fi
+  GQLGENC_VERSION: v0.25.1
   MOCKERY_BIN: "{{.GOPATH}}/bin/mockery"
   MOCKERY_MAJOR_VERSION: v2
   MOCKERY_VERSION: "{{.MOCKERY_MAJOR_VERSION}}.46.0"
@@ -125,6 +126,13 @@ tasks:
       - task: golangci-lint-install
       - golangci-lint cache clean
       - task: golangci-lint-run
+  gqlgenc-install:
+    silent: true
+    cmds:
+      - |
+        if ! gqlgenc version | grep -q {{.GQLGENC_VERSION}}; then
+          go install github.com/Yamashou/gqlgenc@{{.GQLGENC_VERSION}}
+        fi
   lint:
     silent: true
     deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ vars:
       else
         nproc
       fi
-  GQLGENC_VERSION: v0.25.1
+  GQLGENC_VERSION: v0.25.4
   MOCKERY_BIN: "{{.GOPATH}}/bin/mockery"
   MOCKERY_MAJOR_VERSION: v2
   MOCKERY_VERSION: "{{.MOCKERY_MAJOR_VERSION}}.46.0"


### PR DESCRIPTION
https://github.com/Yamashou/gqlgenc

If this will be bumped to a greater version in the future, endusers have to start using a newer version of the action.