### PR TITLE
feat: [#113] Show golangci-lint suggestion line by line to facilitate fixing it

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -113,6 +113,7 @@ tasks:
         golangci-lint run \
           --build-tags component,e2e,integration \
           --concurrency {{.GOLANG_PARALLEL_TESTS}} \
+          --out-format=colored-line-number \
           --timeout 2m30s \
           --verbose
   golangci-lint:


### PR DESCRIPTION
Currently, the suggestions are hardly readable. Adding this option shows the issues line by line which makes them easier to fix.