### PR TITLE
fix: [#117] Use preserved TrivyDBs from AWS ECR to prevent bump into rate limiting by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 | trivy-action-db              | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
 | trivy-action-java-db         | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
 
-Note: If an x is registered in the Default column, refer to the action.yml for
-the corresponding value.
+Note: If an **x** is registered in the Default column, refer to the
+[action.yml](action.yml) for the corresponding value.
 
 <!-- markdownlint-enable MD013 -->
 

--- a/README.md
+++ b/README.md
@@ -87,17 +87,19 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 
 <!-- markdownlint-disable MD013 -->
 
-| Option                             | Default                              | Required | Description                                                                                    |
-| :--------------------------------- | :----------------------------------- | -------- | :--------------------------------------------------------------------------------------------- |
-| code-coverage-expected             | 80                                   |          |                                                                                                |
-| gci                                | true                                 |          | Check for 'incorrect import order'. If failed then instructions are shown to resolve the issue |
-| golang-unit-tests-exclusions       | ' '                                  |          |                                                                                                |
-| golangci-lint-version              | v1.55.2                              |          |                                                                                                |
-| golang-number-of-tests-in-parallel | 4                                    |          |                                                                                                |
-| task-version                       |                                      |          |                                                                                                |
-| token                              | ' '                                  |          | GitHub token that is required to pull cached Trivy DB images                                   |
-| trivy-action-db                    | ghcr.io/aquasecurity/trivy-db:2      |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
-| trivy-action-java-db               | ghcr.io/aquasecurity/trivy-java-db:1 |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
+| Option                       | Default | Required | Description                                                                                    |
+| :--------------------------- | :------ | -------- | :--------------------------------------------------------------------------------------------- |
+| code-coverage-expected       | x       |          |                                                                                                |
+| gci                          | x       |          | Check for 'incorrect import order'. If failed then instructions are shown to resolve the issue |
+| golang-unit-tests-exclusions | x       |          |                                                                                                |
+| task-version                 | x       |          |                                                                                                |
+| testing-type                 |         |          |                                                                                                |
+| token                        |         |          | GitHub token that is required to pull cached Trivy DB images                                   |
+| trivy-action-db              | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
+| trivy-action-java-db         | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
+
+Note: If an x is registered in the Default column, refer to the action.yml for
+the corresponding value.
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yml
+++ b/action.yml
@@ -15,13 +15,6 @@ inputs:
     default: " "
     description: |
       The Golang paths that should be excluded from unit testing.
-  golangci-lint-version:
-    default: v1.55.2
-    description: |
-      The Golangci-lint version that has to be installed and used.
-  golang-number-of-tests-in-parallel:
-    description: |
-      Number of test in parallel.
   task-version:
     default: v3.39.2
     description: |
@@ -29,18 +22,18 @@ inputs:
   testing-type:
     description: |
       The testing type, e.g. integration, unit or some other.
+  token:
+    description: |
+      A token is required to allow the mcvs-golang-action to pull the
+      cached trivy DBs to prevent bump into rate limits.
   trivy-action-db:
     default: "ghcr.io/aquasecurity/trivy-db:2"
     description: |
       OCI repository to retrieve trivy-db from.
   trivy-action-java-db:
+    default: "ghcr.io/aquasecurity/trivy-java-db:1"
     description: |
       OCI repository to retrieve trivy-java-db from.
-    default: "ghcr.io/aquasecurity/trivy-java-db:1"
-  token:
-    description: |
-      A token is required to allow the mcvs-golang-action to pull the
-      cached trivy DBs to prevent bump into pull rate limits.
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -27,11 +27,11 @@ inputs:
       A token is required to allow the mcvs-golang-action to pull the
       cached trivy DBs to prevent bump into rate limits.
   trivy-action-db:
-    default: "ghcr.io/aquasecurity/trivy-db:2"
+    default: "public.ecr.aws/aquasecurity/trivy-db:2"
     description: |
       OCI repository to retrieve trivy-db from.
   trivy-action-java-db:
-    default: "ghcr.io/aquasecurity/trivy-java-db:1"
+    default: "public.ecr.aws/aquasecurity/trivy-java-db:1"
     description: |
       OCI repository to retrieve trivy-java-db from.
 runs:


### PR DESCRIPTION
* Use preserved TrivyDBs to prevent bump into rate limiting issues by default.
* Removed duplicated snippet from the table in the README by referring to the action.yml.