### PR TITLE
fix: [#116] Sed addition for inserts if task run on a Darwin machine

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,6 +19,11 @@ vars:
   MOCKERY_BIN: "{{.GOPATH}}/bin/mockery"
   MOCKERY_MAJOR_VERSION: v2
   MOCKERY_VERSION: "{{.MOCKERY_MAJOR_VERSION}}.46.0"
+  SED_INSERT_ADDITION:
+    sh: |
+      if [ "$(uname -s)" = "Darwin" ]; then
+        echo "\"\""
+      fi
   YQ_MAJOR_VERSION: v4
   YQ_VERSION: "{{.YQ_MAJOR_VERSION}}.44.3"
 


### PR DESCRIPTION
Use `{{.SED_INSERT_ADDITION}}` within the Taskfile that includes the remote to ensure that `sed -i` works on both Darwin and Linux machines.