### PR TITLE
fix: Remote lint as alternative for make lint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -151,6 +151,10 @@ tasks:
         fi
   lint:
     silent: true
+    cmds:
+      - task: golangci-lint
+  lint-with-gci:
+    silent: true
     deps:
       - task: gci
       - task: golangci-lint


### PR DESCRIPTION
Allows users to issue `task remote:lint` as an alternative to `make lint`. This will prevent that one has to create individual mappings in each repository.