### PR TITLE
Allow user to customise gci sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ If you are new to Task, you may want to check out the following resources:
 - Instructions to [configure completions](https://taskfile.dev/installation/#setup-completions)
 - [Integrations](https://taskfile.dev/integrations/) with e.g. Visual Studio Code, Sublime and IntelliJ.
 
+### Configuration
+
+The `Taskfile.yml` in this project defines a number of variables. Some of these
+can be overridden when including this Taskfile in your project. See the example
+below, where the `GCI_SECTIONS` variable is overridden, for how to do this.
+
+The following variables can be overridden:
+
+| Variable             | Description                                                                                                                     |
+| :------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `GCI_SECTION`        | Define how `gci` processes inputs (see the [gci README](https://github.com/daixiang0/gci?tab=readme-ov-file#usage) for details) |                                                                                               |
+
 ## Usage
 
 ### Locally
@@ -78,6 +90,19 @@ You can use `task --list-all` to get a list of all available tasks.
 Alternatively, if you have [configured
 completions](https://taskfile.dev/installation/#setup-completions) in your
 shell, you can tab to get a list of available tasks.
+
+If you want to override one of the variables in our Taskfile, you'll have adjust the `includes` sections like this:
+
+```yml
+---
+...
+
+includes:
+  remote:
+    taskfile: {{.REMOTE_URL}}/{{.REMOTE_URL_REPO}}/{{.REMOTE_URL_REF}}/Taskfile.yml
+    vars:
+      GCI_SECTIONS: '-s standard -s default -s alias'
+```
 
 ### GitHub
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,7 @@ vars:
   BUILD_TAGS: component,e2e,integration
   COVERPROFILE: profile.cov
   GCI_VERSION: 0.13.5
+  GCI_SECTIONS: '{{.GCI_SECTIONS | default "-s standard -s default"}}'
   GOLANGCI_LINT_VERSION: 1.61.0
   GOLANG_PARALLEL_TESTS:
     sh: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,7 +105,7 @@ tasks:
     cmds:
       - task: gci-install
       - |
-        if ~/go/bin/gci list --skip-generated . | grep "\.go$"; then
+        if ~/go/bin/gci list --skip-generated {{.GCI_SECTIONS}} . | grep "\.go$"; then
           echo "One or more golang files detected with: 'incorrect import order':"
           echo " * Observe: '~/go/bin/gci diff --skip-generated .'"
           echo " * Resolve: '~/go/bin/gci write --skip-generated .'"
@@ -116,7 +116,7 @@ tasks:
     silent: true
     cmds:
       - task: gci-install
-      - ~/go/bin/gci write --skip-generated -s standard -s default .
+      - ~/go/bin/gci write --skip-generated {{.GCI_SECTIONS}} .
   golangci-lint-install:
     silent: true
     cmds:


### PR DESCRIPTION
To allow the user of these tasks to specify their own sections, I've introduced the GCI_SECTIONS variable ~~(which is not defined on purpose)~~.

This also fixes the mismatch between the `gci` and `gci-write` tasks where the latter did specify sections and the former did not.