### PR TITLE
fix: Add a code owners file to ensure default reviewers are added to PRs that get created

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# sorted alphabetically
+* @gitbluf @jherrerasbp @sbp-bvanb


### PR DESCRIPTION
Add a code owners file to ensure default reviewers are added to PRs that get created