### PR TITLE
fix: Ignore JSON when running OPA as it only supports rego

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -254,11 +254,13 @@ tasks:
     silent: true
     cmds:
       - |
-        for dir in $(find . -type f -name '*.rego' -exec dirname {} \; | sort -u); do
-          echo "Running opa test in directory: $dir"
-          (cd "$dir" && opa test . -v --explain={{.QUERY_EXPLANATION}})
+        opa_cmd="opa test . --ignore \"*.json\""
 
-          opa_code_coverage_overview=$(cd "$dir" && opa test . -c)
+        for dir in $(find . -type f -name '*.rego' -exec dirname {} \; | sort -u); do
+          echo "Running ${opa_cmd} in directory: $dir"
+          (cd "$dir" && ${opa_cmd} -v --explain={{.QUERY_EXPLANATION}})
+
+          opa_code_coverage_overview=$(cd "$dir" && ${opa_cmd} -c)
           echo "OPA code coverage overview:"
           echo "${opa_code_coverage_overview}"
 


### PR DESCRIPTION
This pull request includes changes to the `Taskfile.yml` to improve the handling of OPA tests by centralizing the OPA command into a variable. This change aims to simplify the command execution and make the script more maintainable.

Improvements to OPA test command handling:

* [`Taskfile.yml`](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eR257-R263): Introduced a new variable `opa_cmd` to store the OPA test command and updated the script to use this variable for running tests, displaying explanations, and generating code coverage overview.
* JSON files have to be ignored to prevent "merge" errors while running OPA.