### PR TITLE
fix: [#147] Ensure that GOBIN is set to avoid assuming its value

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,7 +12,12 @@ vars:
   GCI: "{{.GOBIN}}/gci"
   GCI_SECTIONS: '{{.GCI_SECTIONS | default "-s standard -s default"}}'
   GCI_VERSION: 0.13.5
-  GOBIN: ~/go/bin
+  GOBIN:
+    sh: |
+      if [ -z "${GOBIN}" ]; then
+        echo "GOBIN has not been not set. Ensure that it has been set on the system."
+        exit 1
+      fi
   GOFUMPT_VERSION: v0.7.0
   GOLANGCI_LINT_VERSION: 1.61.0
   GOLANG_PARALLEL_TESTS:


### PR DESCRIPTION
This pull request includes a new task to check if the `GOBIN` environment variable has been set in the `Taskfile.yml`. The most important change is the addition of a default task that runs this check.

New task addition:

* [`Taskfile.yml`](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eR49-R60): Added a `default` task with a description and command to check whether `GOBIN` has been set by default, and a `check-gobin` task to perform the actual check and provide an error message if `GOBIN` is not set.