### PR TITLE
fix: Lint and unit tests require a token sometimes for getting required binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ benefits from improvements made here (e.g. new tasks or improvements in the
 tasks).
 
 If you are new to Task, you may want to check out the following resources:
+
 - [Installation instructions](https://taskfile.dev/installation/)
 - Instructions to [configure completions](https://taskfile.dev/installation/#setup-completions)
 - [Integrations](https://taskfile.dev/integrations/) with e.g. Visual Studio Code, Sublime and IntelliJ.
@@ -51,9 +52,9 @@ below, where the `GCI_SECTIONS` variable is overridden, for how to do this.
 
 The following variables can be overridden:
 
-| Variable             | Description                                                                                                                     |
-| :------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| `GCI_SECTION`        | Define how `gci` processes inputs (see the [gci README](https://github.com/daixiang0/gci?tab=readme-ov-file#usage) for details) |                                                                                               |
+| Variable      | Description                                                                                                                     |
+| :------------ | :------------------------------------------------------------------------------------------------------------------------------ | --- |
+| `GCI_SECTION` | Define how `gci` processes inputs (see the [gci README](https://github.com/daixiang0/gci?tab=readme-ov-file#usage) for details) |     |
 
 ## Usage
 
@@ -95,14 +96,13 @@ If you want to override one of the variables in our Taskfile, you'll have adjust
 
 ```yml
 ---
-...
-
+---
 includes:
   remote:
     taskfile: >-
       {{.REMOTE_URL}}/{{.REMOTE_URL_REPO}}/{{.REMOTE_URL_REF}}/Taskfile.yml
     vars:
-      GCI_SECTIONS: '-s standard -s default -s alias'
+      GCI_SECTIONS: "-s standard -s default -s alias"
 ```
 
 ### GitHub
@@ -146,16 +146,17 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 
 <!-- markdownlint-disable MD013 -->
 
-| Option                       | Default | Required | Description                                                                                    |
-| :--------------------------- | :------ | -------- | :--------------------------------------------------------------------------------------------- |
-| code-coverage-expected       | x       |          |                                                                                                |
-| gci                          | x       |          | Check for 'incorrect import order'. If failed then instructions are shown to resolve the issue |
-| golang-unit-tests-exclusions | x       |          |                                                                                                |
-| task-version                 | x       |          |                                                                                                |
-| testing-type                 |         |          |                                                                                                |
-| token                        |         |          | GitHub token that is required to pull cached Trivy DB images                                   |
-| trivy-action-db              | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
-| trivy-action-java-db         | x       |          | Replace this with a cached image to prevent bump into pull rate limiting issues                |
+| Option                                          | Default | Required |
+| :---------------------------------------------- | :------ | -------- |
+| code-coverage-expected                          | x       |          |
+| gci                                             | x       |          |
+| github-token-for-downloading-private-go-modules |         |          |
+| golang-unit-tests-exclusions                    | x       |          |
+| task-version                                    | x       |          |
+| testing-type                                    |         |          |
+| token                                           |         |          |
+| trivy-action-db                                 | x       |          |
+| trivy-action-java-db                            | x       |          |
 
 Note: If an **x** is registered in the Default column, refer to the
 [action.yml](action.yml) for the corresponding value.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     default: "true"
     description: |
       Whether to check gci. Disable if the project provides an alternative way.
+  github-token-for-downloading-private-go-modules:
+    description: |
+      Whether private go modules have to be downloaded.
   golang-unit-tests-exclusions:
     default: " "
     description: |
@@ -55,6 +58,10 @@ runs:
           major_version=$(echo "${{ inputs.task-version }}" | sed -E 's/^v([0-9]+).*/\1/')
           go install github.com/go-task/task/v${major_version}/cmd/task@${{ inputs.task-version }}
         fi
+    - run: |
+        git config --global url.https://${{ inputs.github-token-for-downloading-private-go-modules }}@github.com/.insteadOf https://github.com/
+      shell: bash
+      if: ${{ inputs.github-token-for-downloading-private-go-modules != '' }}
     # yamllint enable rule:line-length
     #
     # Verify downloaded dependencies.
@@ -77,8 +84,6 @@ runs:
     - name: gci
       if: inputs.gci == 'true' && inputs.testing-type == 'lint'
       shell: bash
-      env:
-        TASK_X_REMOTE_TASKFILES: 1
       run: |
         task remote:gci --yes
     #
@@ -141,7 +146,7 @@ runs:
       if: inputs.testing-type == 'lint'
       shell: bash
       env:
-        TASK_X_REMOTE_TASKFILES: 1
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         task remote:golangci-lint --yes
     #
@@ -151,7 +156,7 @@ runs:
       if: inputs.testing-type == 'unit'
       shell: bash
       env:
-        TASK_X_REMOTE_TASKFILES: 1
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         task remote:test --yes
     #


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `action.yml` files to improve documentation and enhance the configuration of GitHub Actions for the project. The most important changes include the addition of a new input for downloading private Go modules, updates to the formatting of tables in the README, and changes to the environment variables used in the GitHub Actions workflow.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R56): Improved formatting of tables and added a new option for `github-token-for-downloading-private-go-modules` in the list of variables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R56) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R159)

GitHub Actions configuration:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R14-R16): Added a new input for `github-token-for-downloading-private-go-modules` to handle private Go modules.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R61-R64): Updated the GitHub Actions workflow to configure Git with the new input for downloading private Go modules.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L144-R149): Changed the environment variable from `TASK_X_REMOTE_TASKFILES` to `GITHUB_TOKEN` for running remote tasks in the lint and unit test steps. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L144-R149) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L154-R159)