### PR TITLE
fix: Omit ~/go/bin from task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,11 @@ vars:
   GOBIN:
     sh: |
       if [ -z "${GOBIN}" ]; then
+        if [ -n "${GITHUB_ACTIONS}" ]; then
+          echo /home/runner/go/bin
+          exit 0
+        fi
+
         echo "GOBIN has not been not set. Ensure that it has been set on the system."
         exit 1
       fi
@@ -157,6 +162,11 @@ tasks:
     cmds:
       - task: gci-install
       - "{{.GCI}} write --skip-generated {{.GCI_SECTIONS}} ."
+  golang-log:
+    cmds:
+      - |
+        echo "GOBIN: {{.GOBIN}}"
+        echo "GOLANG_PARALLEL_TESTS: {{.GOLANG_PARALLEL_TESTS}}"
   golangci-lint-install:
     silent: true
     cmds:
@@ -169,8 +179,8 @@ tasks:
   golangci-lint-run:
     silent: true
     cmds:
+      - task: golang-log
       - |
-        echo "GOLANG_PARALLEL_TESTS: {{.GOLANG_PARALLEL_TESTS}}"
         golangci-lint run \
           --build-tags {{.BUILD_TAGS}} \
           --concurrency {{.GOLANG_PARALLEL_TESTS}} \
@@ -325,8 +335,8 @@ tasks:
     desc: run unit tests
     silent: true
     cmds:
+      - task: golang-log
       - |
-        echo "GOLANG_PARALLEL_TESTS: {{.GOLANG_PARALLEL_TESTS}}"
         go test \
           -p {{.GOLANG_PARALLEL_TESTS}} \
           -race \

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
       if: inputs.testing-type == 'component' || inputs.testing-type == 'coverage' || inputs.testing-type == 'integration' || inputs.testing-type == 'lint' || inputs.testing-type == 'unit'
       shell: bash
       run: |
-        if ! ~/go/bin/task --version | grep -q "Task version: ${{ inputs.task-version }}"; then
+        if ! task --version | grep -q "Task version: ${{ inputs.task-version }}"; then
           major_version=$(echo "${{ inputs.task-version }}" | sed -E 's/^v([0-9]+).*/\1/')
           go install github.com/go-task/task/v${major_version}/cmd/task@${{ inputs.task-version }}
         fi


### PR DESCRIPTION
This pull request includes changes to the `Taskfile.yml` and `action.yml` files to improve the handling of the `GOBIN` environment variable and streamline the task version check. The most important changes include adding conditional logic for `GOBIN` in GitHub Actions, updating task commands to echo `GOBIN`, and simplifying the task version check in the GitHub Action workflow.

Improvements to `GOBIN` handling:

* [`Taskfile.yml`](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eR18-R22): Added conditional logic to set `GOBIN` to `/home/runner/go/bin` if running in GitHub Actions.
* [`Taskfile.yml`](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eR178): Updated task commands to echo the value of `GOBIN` for better visibility during execution. [[1]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eR178) [[2]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eR335)

Streamlining task version check:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L57-R57): Simplified the task version check by removing the hardcoded path to the `task` binary and relying on the system's `PATH`.