### PR TITLE
fix: Extend timeout golangci-lint to default 3min with the ability to override it and override build-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Alternatively, if you have [configured
 completions](https://taskfile.dev/installation/#setup-completions) in your
 shell, you can tab to get a list of available tasks.
 
-If you want to override one of the variables in our Taskfile, you'll have adjust the `includes` sections like this:
+If you want to override one of the variables in our Taskfile, you will have to
+adjust the `includes` sections like this:
 
 ```yml
 ---
@@ -106,6 +107,8 @@ includes:
         -s default
         -s alias
 ```
+
+Note: same goes for the `GOLANGCI_LINT_RUN_TIMEOUT_MINUTES` setting.
 
 ### GitHub
 
@@ -150,6 +153,7 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 
 | Option                                          | Default | Required |
 | :---------------------------------------------- | :------ | -------- |
+| build-tags                                      | x       |          |
 | code-coverage-expected                          | x       |          |
 | gci                                             | x       |          |
 | github-token-for-downloading-private-go-modules |         |          |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,7 +7,7 @@ vars:
   # Variables that have to be defined first as they are used in other variables.
   OS_TYPE_MAC: Darwin
   # Variables that are sorted alphabetically and are used in the tasks.
-  BUILD_TAGS: component,e2e,integration
+  BUILD_TAGS: '{{ .BUILD_TAGS | default "component,e2e,integration" }}'
   COVERPROFILE: profile.cov
   GCI: "{{.GOBIN}}/gci"
   GCI_SECTIONS: '{{.GCI_SECTIONS | default "-s standard -s default"}}'
@@ -25,6 +25,7 @@ vars:
       fi
   GOFUMPT_VERSION: v0.7.0
   GOLANGCI_LINT_VERSION: 1.61.0
+  GOLANGCI_LINT_RUN_TIMEOUT_MINUTES: "{{.GOLANGCI_LINT_RUN_TIMEOUT_MINUTES | default 3}}"
   GOLANG_PARALLEL_TESTS:
     sh: |
       if [ "$(uname -s)" = "{{.OS_TYPE_MAC}}" ]; then
@@ -185,7 +186,7 @@ tasks:
           --build-tags {{.BUILD_TAGS}} \
           --concurrency {{.GOLANG_PARALLEL_TESTS}} \
           --out-format=colored-line-number \
-          --timeout 2m30s \
+          --timeout {{.GOLANGCI_LINT_RUN_TIMEOUT_MINUTES}}m \
           --verbose
   golangci-lint:
     desc: run golangci-lint

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,8 @@ name: mcvs-golang-action
 description: |
   The Mission Critical Vulnerability Scanner (MCVS) Golang action.
 inputs:
+  build-tags:
+    description: "What kind of code should be checked, e.g. component, e2e"
   code-coverage-expected:
     default: "80"
     description: |
@@ -146,6 +148,7 @@ runs:
       if: inputs.testing-type == 'lint'
       shell: bash
       env:
+        BUILD_TAGS: ${{ inputs.build-tags }}
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         task remote:golangci-lint --yes


### PR DESCRIPTION
Override:
* golangci-lint timeout as some projects take more time to complete the linting.
* override the build tag to ensure that specific kind of code, e.g. e2e, component can be checked.