### PR TITLE
fix: Ensure that GOBIN is set in the context of the Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,6 +23,8 @@ vars:
         echo "GOBIN has not been not set. Ensure that it has been set on the system."
         exit 1
       fi
+      # Ensure that GOBIN is set in the context of this Taskfile.
+      echo ${GOBIN}
   GOFUMPT_VERSION: v0.7.0
   GOLANGCI_LINT_VERSION: 1.61.0
   GOLANGCI_LINT_RUN_TIMEOUT_MINUTES: "{{.GOLANGCI_LINT_RUN_TIMEOUT_MINUTES | default 3}}"


### PR DESCRIPTION
gci and other commands failed locally as gobin was not set in the context of Taskfile is this is set as an env on the machine.