### PR TITLE
feat: Installation and run of MCVS-texttidy to check for forbidden words in projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,18 @@ jobs:
   MCVS-golang-action:
     strategy:
       matrix:
-        testing-type:
-          - component
-          - coverage
-          - integration
-          - lint
-          - security-golang-modules
-          - security-grype
-          - security-trivy
-          - unit
+        args:
+          - { testing-type: "component" }
+          - { testing-type: "coverage" }
+          - { testing-type: "integration" }
+          - { testing-type: "lint", build-tags: "component" }
+          - { testing-type: "lint", build-tags: "e2e" }
+          - { testing-type: "lint", build-tags: "integration" }
+          - { testing-type: "mcvs-texttidy" }
+          - { testing-type: "security-golang-modules" }
+          - { testing-type: "security-grype" }
+          - { testing-type: "security-trivy" }
+          - { testing-type: "unit" }
     runs-on: ubuntu-22.04
     env:
       TASK_X_REMOTE_TASKFILES: 1
@@ -141,9 +144,10 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: schubergphilis/mcvs-golang-action@v0.9.0
         with:
+          build-tags: ${{ matrix.args.build-tags }}
           golang-unit-tests-exclusions: |-
             \(cmd\/some-app\|internal\/app\/some-app\)
-          testing-type: ${{ matrix.testing-type }}
+          testing-type: ${{ matrix.args.testing-type }}
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,9 @@ vars:
   GOVULNCHECK_VERSION: v1.1.3
   GQLGENC_VERSION: v0.25.4
   HELM_VERSION: v3.16.2
-  MOCKERY_BIN: "{{.GOPATH}}/bin/mockery"
+  MCVS_TEXTTIDY_BIN: "{{.GOBIN}}/mcvs-texttidy"
+  MCVS_TEXTTIDY_VERSION: 0.1.0
+  MOCKERY_BIN: "{{.GOBIN}}/mockery"
   MOCKERY_MAJOR_VERSION: v2
   MOCKERY_VERSION: "{{.MOCKERY_MAJOR_VERSION}}.46.0"
   OPA_FMT: "{{.GOBIN}}/opa fmt ."
@@ -235,6 +237,24 @@ tasks:
     deps:
       - task: gci
       - task: golangci-lint
+  mcvs-texttidy-install:
+    silent: true
+    cmds:
+      - |
+        if ! {{.MCVS_TEXTTIDY_BIN}} --version | grep -q {{.MCVS_TEXTTIDY_VERSION}}; then
+          go install github.com/schubergphilis/mcvs-texttidy/cmd/mcvs-texttidy@{{.MCVS_TEXTTIDY_VERSION}}
+        fi
+  mcvs-texttidy-run:
+    silent: true
+    cmds:
+      - "{{.MCVS_TEXTTIDY_BIN}}"
+  mcvs-texttidy:
+    desc: |
+      Install and run mcvs-texttidy to check for forbidden words in projects.
+    silent: true
+    cmds:
+      - task: mcvs-texttidy-install
+      - task: mcvs-texttidy-run
   mock-generate:
     desc: generate mocks
     silent: true

--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,14 @@ runs:
       run: |
         task remote:golangci-lint --yes
     #
+    # Run MCVS-texttidy.
+    #
+    - name: mcvs-texttidy
+      if: inputs.testing-type == 'mcvs-texttidy'
+      shell: bash
+      run: |
+        task remote:mcvs-texttidy --yes
+    #
     # Unit tests.
     #
     - name: unit tests


### PR DESCRIPTION
Check for forbidden words in a project and let the pipeline fail.