### PR TITLE
fix: Update golangci-lint to 1.64.2

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,7 +26,7 @@ vars:
       # Ensure that GOBIN is set in the context of this Taskfile.
       echo ${GOBIN}
   GOFUMPT_VERSION: v0.7.0
-  GOLANGCI_LINT_VERSION: 1.61.0
+  GOLANGCI_LINT_VERSION: 1.64.2
   GOLANGCI_LINT_RUN_TIMEOUT_MINUTES: "{{.GOLANGCI_LINT_RUN_TIMEOUT_MINUTES | default 3}}"
   GOLANG_PARALLEL_TESTS:
     sh: |


### PR DESCRIPTION
The existing linter does not work in projects that use version golang 1.24.0.