### PR TITLE
fix: Increase timeout otherwise testing, listing & coverage fail

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,7 @@ tasks:
         vars:
           TEST_EXTRA_ARGS: >-
             -coverpkg=$(go list --tags={{.TEST_TAGS}} ./... | grep -v '{{.CODE_COVERAGE_FILE_EXCLUSIONS}}' | tr '\n' ',')
-            -coverprofile={{.COVERPROFILE}} -timeout {{.CODE_COVERAGE_TIMEOUT}}
+            -coverprofile={{.COVERPROFILE}}
           TEST_TAGS: integration
       - |
         code_coverage_output=$(go tool cover -func {{.COVERPROFILE}})
@@ -103,7 +103,7 @@ tasks:
         vars:
           TEST_EXTRA_ARGS: >-
             -coverpkg=$(go list --tags={{.TEST_TAGS}} ./... | grep -v '{{.CODE_COVERAGE_FILE_EXCLUSIONS}}' | tr '\n' ',')
-            -coverprofile={{.COVERPROFILE}} -timeout {{.CODE_COVERAGE_TIMEOUT}}
+            -coverprofile={{.COVERPROFILE}}
           TEST_TAGS: integration
       - |
         go tool cover \
@@ -367,7 +367,8 @@ tasks:
           --tags={{.TEST_TAGS}} \
           -v \
           ./... \
-          {{.TEST_EXTRA_ARGS}}
+          {{.TEST_EXTRA_ARGS}} \
+          -timeout {{.TEST_TIMEOUT}}
   test-component:
     desc: run component tests
     silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,7 @@ tasks:
         vars:
           TEST_EXTRA_ARGS: >-
             -coverpkg=$(go list --tags={{.TEST_TAGS}} ./... | grep -v '{{.CODE_COVERAGE_FILE_EXCLUSIONS}}' | tr '\n' ',')
-            -coverprofile={{.COVERPROFILE}}
+            -coverprofile={{.COVERPROFILE}} -timeout {{.CODE_COVERAGE_TIMEOUT}}
           TEST_TAGS: integration
       - |
         code_coverage_output=$(go tool cover -func {{.COVERPROFILE}})
@@ -103,7 +103,7 @@ tasks:
         vars:
           TEST_EXTRA_ARGS: >-
             -coverpkg=$(go list --tags={{.TEST_TAGS}} ./... | grep -v '{{.CODE_COVERAGE_FILE_EXCLUSIONS}}' | tr '\n' ',')
-            -coverprofile={{.COVERPROFILE}}
+            -coverprofile={{.COVERPROFILE}} -timeout {{.CODE_COVERAGE_TIMEOUT}}
           TEST_TAGS: integration
       - |
         go tool cover \

--- a/action.yml
+++ b/action.yml
@@ -40,9 +40,9 @@ inputs:
     description: |
       OCI repository to retrieve trivy-java-db from.
   golangci-timeout:
-    default: "6m0s"
+    default: "3m0s"
     description: |
-      Timeout for total work. If <= 0, the timeout is disabled (default 1m0s)
+      Timeout for total work. If <= 0, the timeout is disabled (default 3m0s)
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     default: "public.ecr.aws/aquasecurity/trivy-java-db:1"
     description: |
       OCI repository to retrieve trivy-java-db from.
+  golangci-timeout:
+    default: "6m0s"
+    description: |
+      Timeout for total work. If <= 0, the timeout is disabled (default 1m0s)
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -40,9 +40,13 @@ inputs:
     description: |
       OCI repository to retrieve trivy-java-db from.
   golangci-timeout:
-    default: "3m0s"
+    default: "3"
     description: |
       Timeout for total work. If <= 0, the timeout is disabled (default 3m0s)
+  code-coverage-timeout:
+    default: "9m0s"
+    description: |
+      Timeout for total work.
 runs:
   using: "composite"
   steps:
@@ -204,6 +208,7 @@ runs:
         CODE_COVERAGE_EXPECTED: ${{ inputs.code-coverage-expected }}
         CODE_COVERAGE_FILE_EXCLUSIONS: ${{ inputs.golang-unit-tests-exclusions }}
         GITHUB_TOKEN: ${{ inputs.token }}
+        CODE_COVERAGE_TIMEOUT: ${{ inputs.code-coverage-timeout }}
       run: |
         task remote:coverage --yes
     #

--- a/action.yml
+++ b/action.yml
@@ -163,6 +163,7 @@ runs:
       env:
         BUILD_TAGS: ${{ inputs.build-tags }}
         GITHUB_TOKEN: ${{ inputs.token }}
+        GOLANGCI_LINT_RUN_TIMEOUT_MINUTES: ${{ inputs.golangci-timeout }}
       run: |
         task remote:golangci-lint --yes
     #

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     description: |
       Timeout for total work. If <= 0, the timeout is disabled (default 3m0s)
   test-timeout:
-    default: "9m0s"
+    default: "6m0s"
     description: |
       Timeout for total work.
 runs:

--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,12 @@ inputs:
     default: "3"
     description: |
       Timeout for total work. If <= 0, the timeout is disabled (default 3m0s)
+  code-coverage-timeout:
+    default: "4m0s"
+    description: |
+      Timeout for total work.
   test-timeout:
-    default: "6m0s"
+    default: "4m0s"
     description: |
       Timeout for total work.
 runs:
@@ -208,6 +212,7 @@ runs:
         CODE_COVERAGE_EXPECTED: ${{ inputs.code-coverage-expected }}
         CODE_COVERAGE_FILE_EXCLUSIONS: ${{ inputs.golang-unit-tests-exclusions }}
         GITHUB_TOKEN: ${{ inputs.token }}
+        CODE_COVERAGE_TIMEOUT: ${{ inputs.code-coverage-timeout }}
         TEST_TIMEOUT: ${{ inputs.test-timeout }}
       run: |
         task remote:coverage --yes

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     default: "3"
     description: |
       Timeout for total work. If <= 0, the timeout is disabled (default 3m0s)
-  code-coverage-timeout:
+  test-timeout:
     default: "9m0s"
     description: |
       Timeout for total work.
@@ -208,7 +208,7 @@ runs:
         CODE_COVERAGE_EXPECTED: ${{ inputs.code-coverage-expected }}
         CODE_COVERAGE_FILE_EXCLUSIONS: ${{ inputs.golang-unit-tests-exclusions }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        CODE_COVERAGE_TIMEOUT: ${{ inputs.code-coverage-timeout }}
+        TEST_TIMEOUT: ${{ inputs.test-timeout }}
       run: |
         task remote:coverage --yes
     #

--- a/action.yml
+++ b/action.yml
@@ -200,6 +200,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+        TEST_TIMEOUT: ${{ inputs.test-timeout }}
       run: |
         task remote:test-integration --yes
     #
@@ -213,7 +214,6 @@ runs:
         CODE_COVERAGE_FILE_EXCLUSIONS: ${{ inputs.golang-unit-tests-exclusions }}
         GITHUB_TOKEN: ${{ inputs.token }}
         CODE_COVERAGE_TIMEOUT: ${{ inputs.code-coverage-timeout }}
-        TEST_TIMEOUT: ${{ inputs.test-timeout }}
       run: |
         task remote:coverage --yes
     #


### PR DESCRIPTION
## What & Why

the following commands were timing out

- golangci-lint run 
- test: integration
- coverage

I increased the timeout to 9 minutes

## Possible cause

This happened when I introduced sbom generation, in mcvs-saas 
https://github.com/schubergphilis/mcvs-scanner/pull/775

## Other info

We might have to increase the compute size of the runner somewhere in the future.
