### PR TITLE
fix: [#178] Omit unsupported Mockery parameter output

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -267,7 +267,6 @@ tasks:
         {{.MOCKERY_BIN}} \
           --dir {{.MOCK_GENERATE_DIR}} \
           --name {{.MOCK_GENERATE_INTERFACE_NAME}} \
-          --output {{.MOCK_GENERATE_DIR}}/mocks \
           --tags {{.BUILD_TAGS}}
   opa-fmt:
     desc: check formatting rego files using opa


### PR DESCRIPTION
Supported [config](https://vektra.github.io/mockery/v2.52/configuration/#parameter-descriptions) parameters.