### PR TITLE
fix: [#164] Optional trivyignore and sorted action input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ jobs:
           - { testing-type: "mcvs-texttidy" }
           - { testing-type: "security-golang-modules" }
           - { testing-type: "security-grype" }
-          - { testing-type: "security-trivy" }
+          - { testing-type: "security-trivy", security-trivyignore: "" }
           - { testing-type: "unit" }
     runs-on: ubuntu-22.04
     env:
@@ -147,6 +147,7 @@ jobs:
           build-tags: ${{ matrix.args.build-tags }}
           golang-unit-tests-exclusions: |-
             \(cmd\/some-app\|internal\/app\/some-app\)
+          security-trivyignore: ${{ matrix.args.security-trivyignore }}
           testing-type: ${{ matrix.args.testing-type }}
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     default: "80"
     description: |
       The minimum code coverage.
+  code-coverage-timeout:
+    description: |
+      The duration before calculating the code-coverage times out.
   gci:
     default: "true"
     description: |
@@ -16,14 +19,26 @@ inputs:
   github-token-for-downloading-private-go-modules:
     description: |
       Whether private go modules have to be downloaded.
+  golangci-timeout:
+    description: |
+      The duration before golangci-lint times out. If <= 0, then the timeout is
+      disabled.
   golang-unit-tests-exclusions:
     default: " "
     description: |
       The Golang paths that should be excluded from unit testing.
+  security-trivyignore:
+    default: ".trivyignore"
+    description: |
+      Whether to ignore certain Trivy vulnerabilities or not.
   task-version:
-    default: v3.39.2
+    default: v3.41.0
     description: |
       The Task version that has to be installed and used.
+  test-timeout:
+    description: |
+      The duration before a test times out. Note: this setting can be used for
+      various types of testing, such as unit, integration, etc.
   testing-type:
     description: |
       The testing type, e.g. integration, unit or some other.
@@ -39,18 +54,6 @@ inputs:
     default: "public.ecr.aws/aquasecurity/trivy-java-db:1"
     description: |
       OCI repository to retrieve trivy-java-db from.
-  golangci-timeout:
-    default: "3"
-    description: |
-      Timeout for total work. If <= 0, the timeout is disabled (default 3m0s)
-  code-coverage-timeout:
-    default: "4m0s"
-    description: |
-      Timeout for total work.
-  test-timeout:
-    default: "4m0s"
-    description: |
-      Timeout for total work.
 runs:
   using: "composite"
   steps:
@@ -149,7 +152,7 @@ runs:
         exit-code: "1"
         ignore-unfixed: true
         severity: "CRITICAL,HIGH"
-        trivyignores: .trivyignore
+        trivyignores: ${{ inputs.security-trivyignore }}
     - uses: aquasecurity/trivy-action@0.29.0
       if: inputs.token == '' && inputs.testing-type == 'security-trivy'
       env:
@@ -161,7 +164,7 @@ runs:
         exit-code: "1"
         ignore-unfixed: true
         severity: "CRITICAL,HIGH"
-        trivyignores: .trivyignore
+        trivyignores: ${{ inputs.security-trivyignore }}
     #
     # Run golangci-lint.
     #


### PR DESCRIPTION
* Sorted input parameters.
* Optional trivyignore to ensure that projects that want to enable trivy-security, but do not want to ignore vulnerabilities will not bump into failing pipeline due to missing .trivyignore.