### PR TITLE
fix: [#195] Change logging tests to normal to improve developer experience

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -435,11 +435,18 @@ tasks:
           -race \
           -short \
           --tags={{.TEST_TAGS}} \
-          -v \
           ./... \
           {{.TEST_EXTRA_ARGS}} \
           -timeout {{.TEST_TIMEOUT}}
     desc: run unit tests
+    silent: true
+  test-cicd:
+    cmds:
+      - task: test
+        vars:
+          TEST_EXTRA_ARGS: >-
+            -v
+    desc: test within CICD should contain verbose logging to facilitate debugging
     silent: true
   test-component:
     cmds:
@@ -448,6 +455,13 @@ tasks:
           TEST_TAGS: component
     desc: run component tests
     silent: true
+  test-component-cicd:
+    cmds:
+      - task: test-cicd
+        vars:
+          TEST_TAGS: component
+    desc: run component tests in CICD
+    silent: true
   test-e2e:
     cmds:
       - task: test
@@ -455,12 +469,26 @@ tasks:
           TEST_TAGS: e2e
     desc: run end-to-end tests
     silent: true
+  test-e2e-cicd:
+    cmds:
+      - task: test-cicd
+        vars:
+          TEST_TAGS: e2e
+    desc: run end-to-end tests in CICD
+    silent: true
   test-integration:
     cmds:
       - task: test
         vars:
           TEST_TAGS: integration
     desc: run integration tests
+    silent: true
+  test-integration-cicd:
+    cmds:
+      - task: test-cicd
+        vars:
+          TEST_TAGS: integration
+    desc: run integration tests in CICD
     silent: true
   yq-install:
     cmds:

--- a/action.yml
+++ b/action.yml
@@ -194,7 +194,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        task remote:test --yes
+        task remote:test-cicd --yes
     #
     # Integration tests.
     #
@@ -205,7 +205,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         TEST_TIMEOUT: ${{ inputs.test-timeout }}
       run: |
-        task remote:test-integration --yes
+        task remote:test-integration-cicd --yes
     #
     # Coverage.
     #
@@ -228,4 +228,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        task remote:test-component --yes
+        task remote:test-component-cicd --yes


### PR DESCRIPTION
* Change default logging to normal.
* Introduce `-cicd` option to keep using verbose logging for CICD to ensure that developer can easily find the issue if a pipeline fails.