### PR TITLE
fix: [#199] Keep task update to date unit broken if user installed task using brew

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -245,8 +245,8 @@ tasks:
       - task: yq-install
       - |
         expected_task_version=$(curl -s {{.REMOTE_URL}}/{{.REMOTE_URL_REPO}}/{{.REMOTE_URL_REF}}/action.yml | yq '.inputs.task-version.default')
-        expected_task_major_version=$(echo "${expected_task_version}" | sed -E 's/^v([0-9]+).*/\1/')
-        current_task_version=$(task --version | sed -E 's/Task version: (v[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+        expected_task_major_version=$(echo "${expected_task_version}" | sed -E 's/^([0-9]+).*/\1/')
+        current_task_version=$(task --version | sed -E 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
         if [ -z "${expected_task_version}" ] || [ -z "${current_task_version}" ]; then
           echo "Failed to extract the expected (default) or current version or both for Task. Please check the default task-version input parameter in the .github/workflows/golang.yml."
           exit 1
@@ -255,13 +255,13 @@ tasks:
         if [ "${expected_task_version}" != "${current_task_version}" ]; then
           if [ -n "${GITHUB_ACTIONS}" ]; then
             echo "The task binary: ${current_task_version} differs from the expected: ${expected_task_version}. Updating it..."
-            go install github.com/go-task/task/v${expected_task_major_version}/cmd/task@${expected_task_version}
+            go install github.com/go-task/task/v${expected_task_major_version}/cmd/task@v${expected_task_version}
             exit 0
           fi
 
           echo "The version of the local task binary: ${current_task_version} differs from the expected: ${expected_task_version}."
           echo "Resolve the issue by updating your local task binary to version: ${expected_task_version}."
-          echo "One remediation option is to run: 'go install github.com/go-task/task/v${expected_task_major_version}/cmd/task@${expected_task_version}', but the choice of installation method depends on your preferred way to install Task."
+          echo "A remediation option is to run: 'go install github.com/go-task/task/v${expected_task_major_version}/cmd/task@v${expected_task_version}', but the choice of installation method depends on your preferred way to install Task."
           exit 1
         fi
     silent: true

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: |
       Whether to ignore certain Trivy vulnerabilities or not.
   task-version:
-    default: v3.41.0
+    default: 3.41.0
     description: |
       The Task version that has to be installed and used.
   test-timeout:


### PR DESCRIPTION
If task is installed using brew then the v is omitted.