### PR TITLE
fix: [#203] Instead of throwing an exit 1 if task version differs show a warning to improve the user experience

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -259,10 +259,25 @@ tasks:
             exit 0
           fi
 
-          echo "The version of the local task binary: ${current_task_version} differs from the expected: ${expected_task_version}."
-          echo "Resolve the issue by updating your local task binary to version: ${expected_task_version}."
-          echo "A remediation option is to run: 'go install github.com/go-task/task/v${expected_task_major_version}/cmd/task@v${expected_task_version}', but the choice of installation method depends on your preferred way to install Task."
-          exit 1
+          echo
+          echo "###############################################################"
+          echo "#"
+          echo "# WARNING"
+          echo "#"
+          echo "###############################################################"
+          echo "#"
+          echo "# The version of the local task binary: ${current_task_version}"
+          echo "# differs from the expected: ${expected_task_version}."
+          echo "# Resolve the issue by updating the local task binary to"
+          echo "# version: ${expected_task_version}."
+          echo "# A remediation option is to run:"
+          echo "# 'go install github.com/go-task/task/v${expected_task_major_version}/cmd/task@v${expected_task_version}',"
+          echo "# but the choice of installation method depends on the"
+          echo "# preferred way to install Task."
+          echo "#"
+          echo "###############################################################"
+          echo
+          sleep 3 # to ensure that user will see the message
         fi
     silent: true
   keep-mcvs-golang-action-version-local-taskfile-in-sync-with-github-workflow:


### PR DESCRIPTION
Related to https://github.com/schubergphilis/mcvs-golang-action/issues/199. If users are using brew to install task, an exit 1 was thrown as v is omitted from the version that is installed using brew. To prevent additional issues in the near future, throw a warning instead of an exit 1.
* Show warning that indicates that user should update task.
* Sleep of three seconds to ensure that use is aware of the warning.