### PR TITLE
fix: update code coverage timeout input to use test timeout variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       TASK_X_REMOTE_TASKFILES: 1
+      test-timeout: 10m0s
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: schubergphilis/mcvs-golang-action@v0.9.0
@@ -150,6 +151,8 @@ jobs:
           security-trivyignore: ${{ matrix.args.security-trivyignore }}
           testing-type: ${{ matrix.args.testing-type }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          test-timeout:  ${{ env.test-timeout }}
+          code-coverage-timeout: ${{ env.test-timeout }}
 ```
 
 and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
@@ -160,14 +163,14 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 | :---------------------------------------------- | :------ | -------- |
 | build-tags                                      | x       |          |
 | code-coverage-expected                          | x       |          |
-| code-coverage-timeout                           | x       |          |
+| code-coverage-timeout                           |         |          |
 | gci                                             | x       |          |
 | github-token-for-downloading-private-go-modules |         |          |
 | golangci-timeout                                | x       |          |
 | golang-unit-tests-exclusions                    | x       |          |
 | task-version                                    | x       |          |
 | testing-type                                    |         |          |
-| test-timeout                                    | x       |          |
+| test-timeout                                    |         |          |
 | token                                           |         |          |
 | trivy-action-db                                 | x       |          |
 | trivy-action-java-db                            | x       |          |

--- a/action.yml
+++ b/action.yml
@@ -216,7 +216,7 @@ runs:
         CODE_COVERAGE_EXPECTED: ${{ inputs.code-coverage-expected }}
         CODE_COVERAGE_FILE_EXCLUSIONS: ${{ inputs.golang-unit-tests-exclusions }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        CODE_COVERAGE_TIMEOUT: ${{ inputs.test-timeout }}
+        CODE_COVERAGE_TIMEOUT: ${{ inputs.code-coverage-timeout }}
       run: |
         task remote:coverage --yes
     #

--- a/action.yml
+++ b/action.yml
@@ -216,7 +216,7 @@ runs:
         CODE_COVERAGE_EXPECTED: ${{ inputs.code-coverage-expected }}
         CODE_COVERAGE_FILE_EXCLUSIONS: ${{ inputs.golang-unit-tests-exclusions }}
         GITHUB_TOKEN: ${{ inputs.token }}
-        CODE_COVERAGE_TIMEOUT: ${{ inputs.code-coverage-timeout }}
+        CODE_COVERAGE_TIMEOUT: ${{ inputs.test-timeout }}
       run: |
         task remote:coverage --yes
     #


### PR DESCRIPTION
## what & why

since the coverage is using test under the hood, the test timeout should also affect the coverage task command