### PR TITLE
fix: remove \ from the if value and write the script on one line

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -284,9 +284,7 @@ runs:
     # Upload binaries to release
     #
     - name: Upload binaries to release
-      if: |
-        github.event_name == 'push' && contains(github.ref, 'refs/tags/') && \
-        inputs.release-dir != ''
+      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && inputs.release-dir != ''
       uses: svenstaro/upload-release-action@2.9.0
       with:
         repo_token: ${{ inputs.token }}


### PR DESCRIPTION
## what & why

it seems that multiline scripts do not work for the if clause. I fixed it by writing everything in one line

![image](https://github.com/user-attachments/assets/a1e2a721-facb-4031-8a35-92b6015c5535)

here's proof that it works with the mcvs-scanner repo

https://github.com/schubergphilis/mcvs-scanner/actions/runs/13785080013/job/38551097469