### PR TITLE
fix: [#210] Adjust behavior that assets are added to a release before testing completion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,7 @@ runs:
         cache: false
     - name: install task
       if: |
+        inputs.release-dir != '' || 
         inputs.testing-type == 'component' ||
         inputs.testing-type == 'coverage' ||
         inputs.testing-type == 'integration' ||
@@ -206,7 +207,9 @@ runs:
     # Unit tests.
     #
     - name: unit tests
-      if: inputs.testing-type == 'unit'
+      if: |
+        inputs.release-dir != '' || 
+        inputs.testing-type == 'unit'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
@@ -216,7 +219,9 @@ runs:
     # Integration tests.
     #
     - name: integration tests
-      if: inputs.testing-type == 'integration'
+      if: |
+        inputs.release-dir != '' || 
+        inputs.testing-type == 'integration'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
@@ -227,7 +232,9 @@ runs:
     # Coverage.
     #
     - name: code coverage
-      if: inputs.testing-type == 'coverage'
+      if: |
+        inputs.release-dir != '' || 
+        inputs.testing-type == 'coverage'
       shell: bash
       env:
         CODE_COVERAGE_EXPECTED: ${{ inputs.code-coverage-expected }}
@@ -240,7 +247,9 @@ runs:
     # Component tests.
     #
     - name: component tests
-      if: inputs.testing-type == 'component'
+      if: |
+        inputs.release-dir != '' || 
+        inputs.testing-type == 'component'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -261,7 +261,8 @@ runs:
       run: |
         mkdir -p "$BUILD_DIR"
         if [ -n "${{ inputs.release-build-tags }}" ]; then
-          go build -tags "${{ inputs.release-build-tags }}" -o "$BUILD_DIR/main" "$SOURCE_FILE"
+          go build -tags "${{ inputs.release-build-tags }}" -o \
+            "$BUILD_DIR/main" "$SOURCE_FILE"
         else
           go build -o "$BUILD_DIR/main" "$SOURCE_FILE"
         fi
@@ -284,7 +285,10 @@ runs:
     # Upload binaries to release
     #
     - name: Upload binaries to release
-      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && inputs.release-dir != ''
+      if: |
+        github.event_name == 'push' && 
+        contains(github.ref, 'refs/tags/') && 
+        inputs.release-dir != ''
       uses: svenstaro/upload-release-action@2.9.0
       with:
         repo_token: ${{ inputs.token }}


### PR DESCRIPTION
require testing to run as well before assets are added to the release