### PR TITLE
build(deps): Update the default version of Task

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
     description: |
       Whether to ignore certain Trivy vulnerabilities or not.
   task-version:
-    default: 3.41.0
+    default: 3.42.1
     description: |
       The Task version that has to be installed and used.
   test-timeout:


### PR DESCRIPTION
There's a new version of task available. See links below for the changelogs:
- [v3.42.0 - 2025-03-08](https://taskfile.dev/changelog/#v3420---2025-03-08)
- [v3.42.1 - 2025-03-10](https://taskfile.dev/changelog/#v3421---2025-03-10)
