### PR TITLE
fix: Omit major versions while installing versions and add GCI skip-generated to default as some projects are omitting it

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,8 +43,7 @@ vars:
   MCVS_TEXTTIDY_BIN: "{{.GOBIN}}/mcvs-texttidy"
   MCVS_TEXTTIDY_VERSION: 0.1.0
   MOCKERY_BIN: "{{.GOBIN}}/mockery"
-  MOCKERY_MAJOR_VERSION: v2
-  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "{{.MOCKERY_MAJOR_VERSION}}.52.2"}}'
+  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v2.52.2"}}'
   OPA_FMT: "{{.GOBIN}}/opa fmt ."
   OPA_VERSION: v0.70.0
   OS_COMMAND: uname
@@ -60,8 +59,7 @@ vars:
         echo "\"\""
       fi
   TEST_TIMEOUT: '{{.TEST_TIMEOUT | default "4m0s"}}'
-  YQ_MAJOR_VERSION: v4
-  YQ_VERSION: "{{.YQ_MAJOR_VERSION}}.44.3"
+  YQ_VERSION: v4.44.3
 tasks:
   build-golang-download-modules:
     cmds:
@@ -343,8 +341,9 @@ tasks:
   mock-generate:
     cmds:
       - |
+        mockery_major_version=$(echo "{{.MOCKERY_VERSION}}" | cut -d '.' -f 1)
         if ! {{.MOCKERY_BIN}} --version | grep "{{.MOCKERY_VERSION}}"; then
-          go install github.com/vektra/mockery/{{.MOCKERY_MAJOR_VERSION}}@{{.MOCKERY_VERSION}}
+          go install github.com/vektra/mockery/${mockery_major_version}@{{.MOCKERY_VERSION}}
         fi
         echo "{{.MOCK_GENERATE_DIR}} {{.MOCK_GENERATE_INTERFACE_NAME}}"
         {{.MOCKERY_BIN}} \
@@ -510,8 +509,9 @@ tasks:
       # unit.
       # - task: keep-local-and-remote-versions-in-sync
       - |
+        yq_major_version=$(echo "{{.YQ_VERSION}}" | cut -d '.' -f 1)
         if ! yq --version | grep -q "version {{.YQ_VERSION}}"; then
           go install \
-            github.com/mikefarah/yq/{{.YQ_MAJOR_VERSION}}@{{.YQ_VERSION}}
+            github.com/mikefarah/yq/${yq_major_version}@{{.YQ_VERSION}}
         fi
     silent: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,7 @@ vars:
   CODE_COVERAGE_TIMEOUT: '{{.CODE_COVERAGE_TIMEOUT | default "4m0s"}}'
   COVERPROFILE: profile.cov
   GCI: "{{.GOBIN}}/gci"
-  GCI_SECTIONS: '{{.GCI_SECTIONS | default "-s standard -s default"}}'
+  GCI_SECTIONS: '{{.GCI_SECTIONS | default "--skip-generated -s standard -s default"}}'
   GCI_VERSION: 0.13.5
   GOFUMPT_VERSION: v0.7.0
   GOLANGCI_LINT_VERSION: 1.64.2
@@ -119,7 +119,6 @@ tasks:
       - task: gci-write
       - go mod tidy
     desc: format go files
-    silent: true
   gofumpt-install:
     cmds:
       - task: keep-local-and-remote-versions-in-sync
@@ -156,10 +155,10 @@ tasks:
     cmds:
       - task: gci-install
       - |
-        if {{.GCI}} list --skip-generated {{.GCI_SECTIONS}} . | grep "\.go$"; then
+        if {{.GCI}} list {{.GCI_SECTIONS}} . | grep "\.go$"; then
           echo "One or more golang files detected with: 'incorrect import order':"
-          echo " * Observe: '{{.GCI}} diff --skip-generated .'"
-          echo " * Resolve: '{{.GCI}} write --skip-generated .'"
+          echo " * Observe: '{{.GCI}} diff .'"
+          echo " * Resolve: '{{.GCI}} write .'"
           exit 1
         fi
     desc: check for incorrect import order with gci
@@ -167,7 +166,7 @@ tasks:
   gci-write:
     cmds:
       - task: gci-install
-      - "{{.GCI}} write --skip-generated {{.GCI_SECTIONS}} ."
+      - "{{.GCI}} write {{.GCI_SECTIONS}} ."
     desc: fix incorrect import order with gci
     silent: true
   golang-log:


### PR DESCRIPTION
* Make major versions dynamic to ensure that one only have to override a version instead of setting a second var as well.
* GCI skip-generated to default as some projects are omitting it.