### PR TITLE
fix: Make mock-generate deprecated and introduce mocks as the new way of generating mocks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,6 +119,7 @@ tasks:
       - task: gci-write
       - go mod tidy
     desc: format go files
+    silent: true
   gofumpt-install:
     cmds:
       - task: keep-local-and-remote-versions-in-sync
@@ -360,17 +361,34 @@ tasks:
     silent: true
   mock-generate:
     cmds:
+      - task: mockery-install
       - |
-        mockery_major_version=$(echo "{{.MOCKERY_VERSION}}" | cut -d '.' -f 1)
-        if ! {{.MOCKERY_BIN}} --version | grep "{{.MOCKERY_VERSION}}"; then
-          go install github.com/vektra/mockery/${mockery_major_version}@{{.MOCKERY_VERSION}}
-        fi
         echo "{{.MOCK_GENERATE_DIR}} {{.MOCK_GENERATE_INTERFACE_NAME}}"
         {{.MOCKERY_BIN}} \
           --dir {{.MOCK_GENERATE_DIR}} \
           --name {{.MOCK_GENERATE_INTERFACE_NAME}} \
           --tags {{.BUILD_TAGS}}
     desc: generate mocks
+    prompt:
+      - |
+        This unit is unsupported from Mockery v3.
+        Please run `task remote:mocks` instead.
+    silent: true
+  mockery-install:
+    cmds:
+      - |
+        mockery_major_version=$(echo "{{.MOCKERY_VERSION}}" | cut -d '.' -f 1)
+        if ! {{.MOCKERY_BIN}} --version | grep "{{.MOCKERY_VERSION}}"; then
+          go install github.com/vektra/mockery/${mockery_major_version}@{{.MOCKERY_VERSION}}
+        fi
+    internal: true
+    silent: true
+  mocks:
+    cmds:
+      - task: mockery-install
+      - |
+        {{.MOCKERY_BIN}}
+      - task: format
     silent: true
   opa-fmt:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,7 +43,7 @@ vars:
   MCVS_TEXTTIDY_BIN: "{{.GOBIN}}/mcvs-texttidy"
   MCVS_TEXTTIDY_VERSION: 0.1.0
   MOCKERY_BIN: "{{.GOBIN}}/mockery"
-  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v2.52.2"}}'
+  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v2.53.3"}}'
   OPA_FMT: "{{.GOBIN}}/opa fmt ."
   OPA_VERSION: v0.70.0
   OS_COMMAND: uname

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -373,6 +373,7 @@ tasks:
       - |
         This unit is unsupported from Mockery v3.
         Please run `task remote:mocks` instead.
+        Are you still sure you want to run `mock-generate`?
     silent: true
   mockery-install:
     cmds:


### PR DESCRIPTION
* Running `mockery` will suffice if one has a .mockery.yaml in a project.
* Updated the default mockery to v2.53.3 to prevent that one has to override the version in each project.