### PR TITLE
fix: Ensure that grype version can be updated as the current default contains high vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,29 +127,29 @@ jobs:
       matrix:
         args:
           - {
-              release-architecture: 'amd64',
-              release-dir: './cmd/path-to-app',
-              release-type: 'binary',
-              release-application-name: 'some-app',
+              release-architecture: "amd64",
+              release-dir: "./cmd/path-to-app",
+              release-type: "binary",
+              release-application-name: "some-app",
             }
           - {
-              release-architecture: 'arm64',
-              release-dir: './cmd/path-to-app',
-              release-type: 'binary',
-              release-application-name: 'some-lambda-func',
-              release-build-tags: 'lambda.norpc',
+              release-architecture: "arm64",
+              release-dir: "./cmd/path-to-app",
+              release-type: "binary",
+              release-application-name: "some-lambda-func",
+              release-build-tags: "lambda.norpc",
             }
-          - { testing-type: 'component' }
-          - { testing-type: 'coverage' }
-          - { testing-type: 'integration' }
-          - { testing-type: 'lint', build-tags: 'component' }
-          - { testing-type: 'lint', build-tags: 'e2e' }
-          - { testing-type: 'lint', build-tags: 'integration' }
-          - { testing-type: 'mcvs-texttidy' }
-          - { testing-type: 'security-golang-modules' }
-          - { testing-type: 'security-grype' }
-          - { testing-type: 'security-trivy', security-trivyignore: '' }
-          - { testing-type: 'unit' }
+          - { testing-type: "component" }
+          - { testing-type: "coverage" }
+          - { testing-type: "integration" }
+          - { testing-type: "lint", build-tags: "component" }
+          - { testing-type: "lint", build-tags: "e2e" }
+          - { testing-type: "lint", build-tags: "integration" }
+          - { testing-type: "mcvs-texttidy" }
+          - { testing-type: "security-golang-modules" }
+          - { testing-type: "security-grype" }
+          - { testing-type: "security-trivy", security-trivyignore: "" }
+          - { testing-type: "unit" }
     runs-on: ubuntu-22.04
     env:
       TASK_X_REMOTE_TASKFILES: 1
@@ -167,7 +167,7 @@ jobs:
           security-trivyignore: ${{ matrix.args.security-trivyignore }}
           testing-type: ${{ matrix.args.testing-type }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          test-timeout:  ${{ env.test-timeout }}
+          test-timeout: ${{ env.test-timeout }}
           code-coverage-timeout: ${{ env.test-timeout }}
 ```
 
@@ -184,6 +184,7 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 | github-token-for-downloading-private-go-modules |         |          |
 | golangci-timeout                                | x       |          |
 | golang-unit-tests-exclusions                    | x       |          |
+| grype-version                                   | x       |          |
 | release-application-name                        |         |          |
 | release-architecture                            |         |          |
 | release-build-tags                              |         |          |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
     default: "go.mod"
     description: |
       The Path to the go.mod or go.work file.
+  grype-version:
+    default: v0.90.0
+    description: The grype version to be used by the anchore/scan-action.
   release-application-name:
     description: |
       The name of the application that has to be released.
@@ -142,6 +145,7 @@ runs:
     - uses: anchore/scan-action@v6.1.0
       if: inputs.token != '' && inputs.testing-type == 'security-grype'
       with:
+        grype-version: ${{ inputs.grype-version }}
         only-fixed: false
         output-format: table
         path: "."


### PR DESCRIPTION
* The current grype v0.87.0 contains high findings. Update it to remediate the issues.
* Apparently, no markdown linter auto formatter was used by previous committer causing the changes in the README.md.
