### PR TITLE
fix: [#217] Exit 1 if go mod not up to date

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,14 @@ runs:
         git config --global url.https://${{ inputs.github-token-for-downloading-private-go-modules }}@github.com/.insteadOf https://github.com/
       shell: bash
       if: ${{ inputs.github-token-for-downloading-private-go-modules != '' }}
+    - run: |
+        go mod tidy
+
+        if [[ -n $(git diff --exit-code) ]]; then
+          echo "A discrepancy has been detected. Has 'go mod tidy' been issued?"
+          exit 1
+        fi
+      shell: bash
     #
     # Verify downloaded dependencies.
     #


### PR DESCRIPTION
Let pipeline if if go mod is outdated to ensure that the go mod is up to date always as it is a security best practice to only use the modules that are in use.