### PR TITLE
fix: test-cicd not working as expected due to not propagated TEST_TAGS var

### DIFF
--- a/build/task.yml
+++ b/build/task.yml
@@ -457,6 +457,7 @@ tasks:
         vars:
           TEST_EXTRA_ARGS: >-
             -v
+          TEST_TAGS: "{{.TEST_TAGS}}"
     desc: test within CICD should contain verbose logging to facilitate debugging
     silent: true
   test-component:


### PR DESCRIPTION
* When task remote:test-integration-cicd was run, one expected to see verbose log. As that did not happen it turned out that the TEST_TAGS was not propagated.