### PR TITLE
build(deps): bump Task from 3.42.1 to 3.43.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
     description: |
       Whether to ignore certain Trivy vulnerabilities or not.
   task-version:
-    default: 3.42.1
+    default: 3.43.3
     description: |
       The Task version that has to be installed and used.
   test-timeout:


### PR DESCRIPTION
Version 3.43.3 was released a while ago. Time to bump the default version here as well.