### PR TITLE
build: [#254] let pipeline fail if mocks are outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ jobs:
           - { testing-type: "lint", build-tags: "e2e" }
           - { testing-type: "lint", build-tags: "integration" }
           - { testing-type: "mcvs-texttidy" }
+          - { testing-type: "mocks-tidy" }
           - { testing-type: "security-golang-modules" }
           - { testing-type: "security-grype" }
           - { testing-type: "security-trivy", security-trivyignore: "" }

--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,7 @@ runs:
         inputs.testing-type == 'integration' ||
         inputs.testing-type == 'lint' ||
         inputs.testing-type == 'mcvs-texttidy' ||
+        inputs.testing-type == 'mocks-tidy' ||
         inputs.testing-type == 'unit'
       shell: bash
       run: |
@@ -140,6 +141,7 @@ runs:
         inputs.testing-type == 'integration' ||
         inputs.testing-type == 'lint' ||
         inputs.testing-type == 'mcvs-texttidy' ||
+        inputs.testing-type == 'mocks-tidy' ||
         inputs.testing-type == 'unit'
       run: |
         go mod tidy
@@ -236,6 +238,14 @@ runs:
       shell: bash
       run: |
         task remote:mcvs-texttidy --yes
+    #
+    # Run mocks-tidy.
+    #
+    - name: mocks-tidy
+      if: inputs.testing-type == 'mocks-tidy'
+      shell: bash
+      run: |
+        task remote:mocks-tidy --yes
     #
     # Unit tests.
     #

--- a/build/task.yml
+++ b/build/task.yml
@@ -41,7 +41,7 @@ vars:
   MCVS_TEXTTIDY_BIN: "{{.GOBIN}}/mcvs-texttidy"
   MCVS_TEXTTIDY_VERSION: 0.1.0
   MOCKERY_BIN: "{{.GOBIN}}/mockery"
-  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v2.53.3"}}'
+  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v3.2.5"}}'
   OPA_FMT: "{{.GOBIN}}/opa fmt ."
   OPA_VERSION: v0.70.0
   OS_COMMAND: uname
@@ -337,7 +337,7 @@ tasks:
     cmds:
       - |
         mockery_major_version=$(echo "{{.MOCKERY_VERSION}}" | cut -d '.' -f 1)
-        if ! {{.MOCKERY_BIN}} --version | grep "{{.MOCKERY_VERSION}}"; then
+        if ! {{.MOCKERY_BIN}} version | grep "{{.MOCKERY_VERSION}}"; then
           go install github.com/vektra/mockery/${mockery_major_version}@{{.MOCKERY_VERSION}}
         fi
     internal: true
@@ -348,6 +348,17 @@ tasks:
       - |
         {{.MOCKERY_BIN}}
       - task: format
+    silent: true
+  mocks-tidy:
+    cmds:
+      - |
+        find . -type d -name 'mocks' -exec rm -r {} +
+      - task: mocks
+      - |
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo "Uncommitted changes detected. Aborting."
+          exit 1
+        fi
     silent: true
   opa-fmt:
     cmds:


### PR DESCRIPTION
* Update mockery to v3 as this version will let the generation of mocks fail if they are defined in mockery.yaml, but non existent.
* Let pipeline fail if mocks are outdated.