### PR TITLE
fix: ctrl + click to file to increase code coverage

### DIFF
--- a/build/task.yml
+++ b/build/task.yml
@@ -89,13 +89,15 @@ tasks:
           TEST_TAGS: integration
           TEST_TIMEOUT: "{{.CODE_COVERAGE_TIMEOUT}}"
       - |
+        local_dir_name="$(basename "$PWD")"
+
         awk '!seen[$0]++' {{.COVERPROFILE}} > {{.COVERPROFILE_UNIQUE}}
         code_coverage_output=$(go tool cover -func {{.COVERPROFILE_UNIQUE}})
         code_coverage_actual=$(echo "${code_coverage_output}" | awk '/total:/ {print $3}' | sed 's/%//')
 
         echo "CODE_COVERAGE_FILE_EXCLUSIONS: {{.CODE_COVERAGE_FILE_EXCLUSIONS}}"
         echo "Code coverage overview:"
-        echo "${code_coverage_output}"
+        echo "${code_coverage_output}" | sed "s|^.*${local_dir_name}/||"
 
         if (( $(echo "${code_coverage_actual} < {{.CODE_COVERAGE_EXPECTED}}" | bc -l) )); then
           echo "The actual code coverage: '${code_coverage_actual}' is too low. Expected: '{{.CODE_COVERAGE_EXPECTED}}'. Resolve the issue by writing more unit and/or integration tests."


### PR DESCRIPTION
* To ensure that ctrl + click to navigate to file with insufficient code coverage will work.

Previous:

```
github.com/schubergphilis/mcvs-scanner/internal/pkg/data/dataset/dataset_helper.go:447:                                        insertFooPlatform                               83.3%
github.com/schubergphilis/mcvs-scanner/internal/pkg/data/dataset/dataset_helper.go:459:                                        insertFooPlatformsAdditional                    0.0%
```

After merging this PR:

```
internal/pkg/data/dataset/dataset_helper.go:447:                                        insertFooPlatform                               83.3%
internal/pkg/data/dataset/dataset_helper.go:459:                                        insertFooPlatformsAdditional                    0.0%
```

Ctrl + click on the shorter links will ensure that vscode will directly go to the location that lacks code coverage and the user can start improving it right away which will save time.