### PR TITLE
build: use action 3.1.0

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -16,6 +16,6 @@ jobs:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: schubergphilis/mcvs-golang-action@lint-git
+      - uses: schubergphilis/mcvs-golang-action@v3.1.0
         with:
           testing-type: ${{ matrix.args.testing-type }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@ version: 3
 
 vars:
   REMOTE_URL: https://raw.githubusercontent.com
-  REMOTE_URL_REF: lint-git
+  REMOTE_URL_REF: v3.1.0
   REMOTE_URL_REPO: schubergphilis/mcvs-golang-action
 
 includes:


### PR DESCRIPTION
Use 3.1.0 action as lint-git branch does not exist anymore.