### PR TITLE
build: move lint-commit to general action

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         args:
+          - testing-type: lint-commit
           - testing-type: lint-git
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         args:
-          - testing-type: lint-commit
           - testing-type: security-golang-modules
           - testing-type: security-grype
           - testing-type: security-trivy

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ jobs:
           - testing-type: "component"
           - testing-type: "coverage"
           - testing-type: "integration"
-          - testing-type: "lint-commit"
           - testing-type: "lint", build-tags: "component"
           - testing-type: "lint", build-tags: "e2e"
           - testing-type: "lint", build-tags: "integration"

--- a/action.yml
+++ b/action.yml
@@ -79,33 +79,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - if: |
-        github.event_name == 'pull_request' &&
-        inputs.testing-type == 'lint-commit'
-      uses: actions/checkout@v4.2.2
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-    #
-    # Commit lint
-    #
-    - if: |
-        github.event_name == 'pull_request' &&
-        inputs.testing-type == 'lint-commit'
-      run: |
-        npm install --save-dev \
-          commitlint-plugin-function-rules \
-          @commitlint/{cli,config-conventional,ensure}
-
-        cat ${GITHUB_ACTION_PATH}/configs/commitlint.config.mjs > \
-          commitlint.config.mjs
-
-        npx commitlint \
-          --from ${{ github.event.pull_request.base.sha }} \
-          --to ${{ github.event.pull_request.head.sha }} \
-          --verbose
-      shell: bash
     #
     # Install task and the golang version that has been defined in the go.mod
     # file.

--- a/configs/commitlint.config.mjs
+++ b/configs/commitlint.config.mjs
@@ -1,6 +1,0 @@
-export default {
-  extends: ["@commitlint/config-conventional"],
-  rules: {
-    "body-max-line-length": [0],
-  },
-};


### PR DESCRIPTION
Move to [mcvs-general-action](https://github.com/schubergphilis/mcvs-general-action/pull/7) as lint-commit is a general action.