### PR TITLE
feat: release os darwin binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ and a [.golangci.yml](https://golangci-lint.run/usage/configuration/).
 | release-architecture                            |         |          |
 | release-build-tags                              |         |          |
 | release-dir                                     |         |          |
+| release-os                                      | x       |          |
 | release-type                                    |         |          |
 | task-install                                    | x       |          |
 | task-version                                    | x       |          |
@@ -231,6 +232,7 @@ jobs:
           - release-application-name: mcvs-image-downloader
             release-architecture: arm64
             release-dir: cmd/mcvs-image-downloader
+            release-os: darwin
             release-type: binary
     runs-on: ubuntu-24.04
     env:
@@ -243,6 +245,7 @@ jobs:
           release-architecture: ${{ matrix.args.release-architecture }}
           release-build-tags: ${{ matrix.args.release-build-tags }}
           release-dir: ${{ matrix.args.release-dir }}
+          release-os: ${{ matrix.args.release-os }}
           release-type: ${{ matrix.args.release-type }}
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,15 @@ inputs:
       The architecture of the release, e.g. amd64, arm64, etc.
   release-build-tags:
     description: |
-      The build tags that have to be used when building the release. eg for \
+      The build tags that have to be used when building the release. e.g. for \
       AWS Lambda, the tag lambda.norpc is used.
   release-dir:
     description: |
       The directory of the main.go file to be compiled and released.
+  release-os:
+    default: linux
+    description: |
+      The OS of the main.go file to be compiled and released.
   release-type:
     description: |
       The type of the release, e.g. binary, zip, etc.
@@ -285,16 +289,19 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         BUILD_DIR: build/${{ inputs.release-type }}/${{ inputs.release-application-name }}/${{ inputs.release-architecture }}
-        GOOS: linux
         GOARCH: ${{ inputs.release-architecture }}
+        GOOS: ${{ inputs.release-os }}
         SOURCE_FILE: ${{ inputs.release-dir }}/main.go
       run: |
-        mkdir -p "$BUILD_DIR"
+        mkdir -p "${BUILD_DIR}"
         if [ -n "${{ inputs.release-build-tags }}" ]; then
-          go build -tags "${{ inputs.release-build-tags }}" -o \
-            "$BUILD_DIR/main" "$SOURCE_FILE"
+          go build \
+            -tags "${{ inputs.release-build-tags }}" \
+            -o "${BUILD_DIR}/main" "${SOURCE_FILE}"
         else
-          go build -o "$BUILD_DIR/main" "$SOURCE_FILE"
+          go build \
+            -ldflags="-X 'main.Version=${{ github.ref_name }}'" \
+            -o "${BUILD_DIR}/main" "${SOURCE_FILE}"
         fi
     #
     # Compute asset name
@@ -304,13 +311,13 @@ runs:
       id: compute_asset_name
       shell: bash
       run: |
-        ASSET_NAME_BASE="${{ inputs.release-application-name }}-${{ github.ref_name }}-linux-${{ inputs.release-architecture }}"
+        ASSET_NAME_BASE="${{ inputs.release-application-name }}-${{ github.ref_name }}-${{ inputs.release-os }}-${{ inputs.release-architecture }}"
         if [ -n "${{ inputs.release-build-tags }}" ]; then
           ASSET_NAME="${ASSET_NAME_BASE}-${{ inputs.release-build-tags }}"
         else
-          ASSET_NAME="$ASSET_NAME_BASE"
+          ASSET_NAME="${ASSET_NAME_BASE}"
         fi
-        echo "asset_name=$ASSET_NAME" >> $GITHUB_OUTPUT
+        echo "asset_name=${ASSET_NAME}" >> $GITHUB_OUTPUT
     #
     # Upload binaries to release
     #


### PR DESCRIPTION
* Release OS darwin binaries to ensure binaries can be run on Darwin.
* Set version when building binaries using `ldflags`. Note: installed binaries using `go install` while show the buildInfo, but binaries require a version that is baked into the binary.