### PR TITLE
fix: ctrl click path not working on mac as sed works slightly different

### DIFF
--- a/build/task.yml
+++ b/build/task.yml
@@ -174,7 +174,7 @@ tasks:
 
         echo "CODE_COVERAGE_FILE_EXCLUSIONS: {{.CODE_COVERAGE_FILE_EXCLUSIONS}}"
         echo "Code coverage overview:"
-        echo "${code_coverage_output}" | sed "s|^[a-z0-9.\.\/]\+\/${local_dir_name}/||"
+        echo "${code_coverage_output}" | cut -d'/' -f4-
 
         echo "CODE_COVERAGE_STRICT: {{.CODE_COVERAGE_STRICT}}"
 


### PR DESCRIPTION
The sed solution is working on Linux, but not on Darwin. By using a more cloud agnostic solution by using `cut` path extraction should work on both Mac and Linux and it will make life easier as one can directly navigate to a particular file in VScode.