### PR TITLE
build: bump golangci-lint to v2.2.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,9 @@ linters:
     # testpackage is disabled as it is a bad practice to make methods public to
     # be able to test them.
     - testpackage
+    # The linter 'wsl' is deprecated (since v2.2.0) due to: new major version.
+    # Replaced by wsl_v5.
+    - wsl
   settings:
     depguard:
       rules:

--- a/build/task.yml
+++ b/build/task.yml
@@ -2,7 +2,7 @@
 # - cmd: steps that will be run sequentially.
 # - deps: tasks that will be run in parallel.
 ---
-version: "3"
+version: 3
 vars:
   # Variables that have to be defined first as they are used in other variables.
   CODE_COVERAGE_EXPECTED:
@@ -39,7 +39,7 @@ vars:
   COVERPROFILE: profile.cov
   COVERPROFILE_UNIQUE: "unique_{{.COVERPROFILE}}"
   GOLANGCI_LINT_CONFIG_PATH: '{{.GOLANGCI_LINT_CONFIG_PATH | default ".golangci.yml"}}'
-  GOLANGCI_LINT_VERSION: 2.1.6
+  GOLANGCI_LINT_VERSION: 2.2.2
   GOLANGCI_LINT_RUN_TIMEOUT_MINUTES: "{{.GOLANGCI_LINT_RUN_TIMEOUT_MINUTES | default 3}}"
   GOLANG_PARALLEL_TESTS:
     sh: |


### PR DESCRIPTION
* noinlineerr
* wsl replaced by wsl_v5

Update `.golangci.yml` snippet as follows:

```
linters:
  default: all
  disable:
    # The linter 'wsl' is deprecated (since v2.2.0) due to: new major version.
    # Replaced by wsl_v5.
    - wsl
```