### PR TITLE
fix: bump mockery to 3.5.3 which is go1.25 compatible

### DIFF
--- a/build/task.yml
+++ b/build/task.yml
@@ -69,7 +69,7 @@ vars:
   MCVS_TEXTTIDY_BIN: "{{.GOBIN}}/mcvs-texttidy"
   MCVS_TEXTTIDY_VERSION: 0.1.0
   MOCKERY_BIN: "{{.GOBIN}}/mockery"
-  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v3.2.5"}}'
+  MOCKERY_VERSION: '{{.MOCKERY_VERSION | default "v3.5.3"}}'
   OPA_BIN: "{{.GOBIN}}/opa"
   OPA_FMT: "{{.OPA_BIN}} fmt ."
   OPA_VERSION: 0.70.0


### PR DESCRIPTION
Executing `task remote:mocks` resulted in: `package requires newer Go version go1.25 (application built with go1.24)" version=v3.2.5`. This is caused as a mockery version built with go1.24 was used.