### PR TITLE
build(deps): bump Task from 3.44.0 to 3.44.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ inputs:
     description: |
       Whether Task should be installed.
   task-version:
-    default: 3.44.0
+    default: 3.44.1
     description: |
       The Task version that has to be installed and used.
   test-timeout:


### PR DESCRIPTION
Task version 3.44.1 was released on July 23rd. Time to bump our default version.