### PR TITLE
fix: update golangci-lint install URL from master to main

### DIFF
--- a/build/task.yml
+++ b/build/task.yml
@@ -270,7 +270,7 @@ tasks:
         if ! golangci-lint --version | grep -q "has version {{.GOLANGCI_LINT_VERSION_WITHOUT_V_PREFIX}}"; then
           echo "Installing golangci-lint version {{.GOLANGCI_LINT_VERSION_WITHOUT_V_PREFIX}}..."
           curl \
-            -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh |\
+            -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh |\
             sh -s -- -b {{.GOBIN}} {{.GOLANGCI_LINT_VERSION}}
         fi
     silent: true


### PR DESCRIPTION
## Summary

Update the golangci-lint installer URL in `build/task.yml` from `master` to `main`.

## Why

The `golangci-lint` project renamed their default branch from `master` to `main`. The install script on the `master` branch is now stale and contains outdated checksums, causing CI pipelines to fail with:

```
hash_sha256_verify checksum for 'golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify <expected> vs <got>
```

The golangci-lint team explicitly documented this in their v2.12.0 and v2.12.1 release notes:

> **Important**: If you are using the install script from the `master` branch:
> `https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh`
> This branch is not used anymore, we are using `main`.

## Change

```diff
- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh
```