### PR TITLE
chore: fix zizmor findings in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       github-actions-all:
         patterns:
@@ -13,6 +15,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       gomod-all:
         patterns:

--- a/.github/workflows/action-sorted-inputs.yml
+++ b/.github/workflows/action-sorted-inputs.yml
@@ -11,7 +11,7 @@ jobs:
   check-action-inputs-sorted:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: Validate input key order in action.yml

--- a/.github/workflows/action-sorted-inputs.yml
+++ b/.github/workflows/action-sorted-inputs.yml
@@ -11,7 +11,9 @@ jobs:
   check-action-inputs-sorted:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Validate input key order in action.yml
         run: |
           inputs_file="action.yml"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -15,7 +15,9 @@ jobs:
           - testing-type: yamllint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: schubergphilis/mcvs-general-action@v0.5.8
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: schubergphilis/mcvs-general-action@f52c4433add29d8eff9036bf37b5b69a2c4cf28b # v0.5.8
         with:
           testing-type: ${{ matrix.args.testing-type }}

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,6 +1,8 @@
+# yamllint disable rule:line-length
 ---
 name: General
-"on": pull_request
+"on":
+  pull_request:
 permissions:
   contents: read
   packages: read
@@ -15,9 +17,9 @@ jobs:
           - testing-type: yamllint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - uses: schubergphilis/mcvs-general-action@f52c4433add29d8eff9036bf37b5b69a2c4cf28b # v0.5.8
+      - uses: schubergphilis/mcvs-general-action@f52c4433add29d8eff9036bf37b5b69a2c4cf28b
         with:
           testing-type: ${{ matrix.args.testing-type }}

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -16,7 +16,9 @@ jobs:
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           task-install: yes

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - uses: ./

--- a/.github/workflows/gomod-go-version-updater.yml
+++ b/.github/workflows/gomod-go-version-updater.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: gomod-go-version-updater-action
 "on":
@@ -11,4 +12,4 @@ jobs:
   gomod-go-version-updater-action:
     runs-on: ubuntu-24.04
     steps:
-      - uses: schubergphilis/gomod-go-version-updater-action@c12bc6c5e4ae85e82ee346115d1657e43121c195 # v0.3.5
+      - uses: schubergphilis/gomod-go-version-updater-action@c12bc6c5e4ae85e82ee346115d1657e43121c195

--- a/.github/workflows/gomod-go-version-updater.yml
+++ b/.github/workflows/gomod-go-version-updater.yml
@@ -11,4 +11,4 @@ jobs:
   gomod-go-version-updater-action:
     runs-on: ubuntu-24.04
     steps:
-      - uses: schubergphilis/gomod-go-version-updater-action@v0.3.5
+      - uses: schubergphilis/gomod-go-version-updater-action@c12bc6c5e4ae85e82ee346115d1657e43121c195 # v0.3.5

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -15,5 +15,7 @@ jobs:
   MCVS-PR-validation-action:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: schubergphilis/mcvs-pr-validation-action@v0.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: schubergphilis/mcvs-pr-validation-action@6f153c01301ab2f92336781173b7f3a796de5f3e # v0.2.2

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: MCVS-PR-validation-action
 "on":
@@ -15,7 +16,7 @@ jobs:
   MCVS-PR-validation-action:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - uses: schubergphilis/mcvs-pr-validation-action@6f153c01301ab2f92336781173b7f3a796de5f3e # v0.2.2
+      - uses: schubergphilis/mcvs-pr-validation-action@6f153c01301ab2f92336781173b7f3a796de5f3e

--- a/.github/workflows/package-version-updater.yml
+++ b/.github/workflows/package-version-updater.yml
@@ -10,7 +10,7 @@ jobs:
   update-package-version-not-updated-by-dependabot:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - env:

--- a/.github/workflows/package-version-updater.yml
+++ b/.github/workflows/package-version-updater.yml
@@ -10,7 +10,9 @@ jobs:
   update-package-version-not-updated-by-dependabot:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - env:
           DEPENDENCIES_LABEL: dependencies
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
         with:
           days-before-stale: 63
           days-before-close: 21

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/stale@v10.3.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-stale: 63
           days-before-close: 21

--- a/.github/workflows/taskfile-sorted-units.yml
+++ b/.github/workflows/taskfile-sorted-units.yml
@@ -9,7 +9,7 @@ jobs:
   taskfile-sorted-units:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - run: |

--- a/.github/workflows/taskfile-sorted-units.yml
+++ b/.github/workflows/taskfile-sorted-units.yml
@@ -9,7 +9,9 @@ jobs:
   taskfile-sorted-units:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: |
           check_sorted() {
             local task_name="$1"

--- a/.github/workflows/taskfile-without-empty-lines.yml
+++ b/.github/workflows/taskfile-without-empty-lines.yml
@@ -8,7 +8,9 @@ jobs:
   taskfile-without-empty-lines:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: |
           yaml_file="./build/task.yml"
           empty_lines=$(grep -n -e '^$' "$yaml_file")

--- a/.github/workflows/taskfile-without-empty-lines.yml
+++ b/.github/workflows/taskfile-without-empty-lines.yml
@@ -8,7 +8,7 @@ jobs:
   taskfile-without-empty-lines:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,17 @@
+# yamllint disable rule:line-length
+---
+name: zizmor
+"on":
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  zizmor:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: woodruffw/zizmor-action@597db4d7dc5730bdc1370197bf5678a5ca028abb
+        with:
+          minimum-severity: low

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa
         with:
           minimum-severity: low

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - uses: woodruffw/zizmor-action@597db4d7dc5730bdc1370197bf5678a5ca028abb
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           minimum-severity: low


### PR DESCRIPTION
## Why zizmor?

[zizmor](https://github.com/woodruffw/zizmor) is a static analysis tool for GitHub Actions workflows. It catches security misconfigurations that are easy to miss in code review but are commonly exploited in supply-chain attacks.

### Findings addressed

**`unpinned-uses`** — Actions pinned to a tag (e.g. `@v1`) can silently change if the tag is force-pushed or hijacked. Pinning to an immutable commit SHA guarantees the exact code that ran in CI today is the same code that runs tomorrow, even if the upstream repo is compromised.

**`artipacked`** — By default `actions/checkout` persists a GitHub token in the local git config so that subsequent `git` commands can authenticate. If any later step in the job (or a transitive action) exfiltrates the workspace, it gets the token for free. Setting `persist-credentials: false` removes the token after checkout unless it is explicitly needed.

**`dependabot-cooldown`** — Without a cooldown, Dependabot can open PRs for a newly published package version within minutes of release. A short window is a known vector for dependency-confusion and typosquatting attacks where a malicious version is published and auto-merged before the community notices. Requiring a minimum 7-day cooldown gives the ecosystem time to vet new releases.

## Validation
```
zizmor --min-severity low .github/
No findings to report. Good job! (32 suppressed)
```