### PR TITLE
feat: run tests via gotestsum to report the number of tests per testing type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,11 @@ Tests are organized using Go build tags:
 - **`e2e`** - End-to-end tests (`*_e2e_test.go` files with `//go:build e2e`)
 - Default (no tag) - Unit tests
 
+All test tasks run through [gotestsum](https://github.com/gotestyourself/gotestsum),
+which prints a summary with the number of tests that have been run for the
+testing type at hand. Set `GOTESTSUM_ENABLED: "false"` to fall back to plain
+`go test`.
+
 ### Security Scanning Flow
 
 1. **osv-scanner** - First line of defense for Go module vulnerabilities
@@ -154,6 +159,8 @@ Available override variables (see [build/task.yml](build/task.yml) lines 47-53):
 - `CODE_COVERAGE_STRICT` - Enforce minimum coverage (default: "true")
 - `GOLANGCI_LINT_CONFIG_PATH` - Path to golangci-lint config (default: ".golangci.yml")
 - `GOLANGCI_LINT_RUN_TIMEOUT_MINUTES` - Linter timeout (default: 3)
+- `GOTESTSUM_ENABLED` - Run tests through gotestsum (default: "true")
+- `GOTESTSUM_FORMAT` - gotestsum output format (default: "testname")
 - `BUILD_TAGS` - Build tags for tests/linting (default: "component,e2e,integration")
 
 ## Using the GitHub Action

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ consists of the following steps:
 - Unit tests.
 - Integration tests.
 - Code coverage.
+- A test summary, including the number of tests that have been run per testing
+  type, using [gotestsum](https://github.com/gotestyourself/gotestsum).
 
 In summary, using this action will ensure that Golang code meets certain
 standards before it will be deployed to production as the assembly line will
@@ -71,6 +73,8 @@ The following variables can be overridden:
 | :-------------------------- | :------------------------------------------------------------------------------------------------------- |
 | `CODE_COVERAGE_STRICT`      | Enables or disables strict enforcement of setting the minimum coverage to the maximum observed coverage. |
 | `GOLANGCI_LINT_CONFIG_PATH` | Defines the path to the golangci-lint configuration file.                                                |
+| `GOTESTSUM_ENABLED`         | Enables or disables running the tests via [gotestsum](https://github.com/gotestyourself/gotestsum). Default: `true`. |
+| `GOTESTSUM_FORMAT`          | The gotestsum [output format](https://github.com/gotestyourself/gotestsum#output-format). Default: `testname`. |
 
 ## Usage
 

--- a/build/task.yml
+++ b/build/task.yml
@@ -62,6 +62,10 @@ vars:
       fi
   GOLINES_BIN: "{{.GOBIN}}/golines"
   GOLINES_VERSION: v0.13.0
+  GOTESTSUM_BIN: "{{.GOBIN}}/gotestsum"
+  GOTESTSUM_ENABLED: '{{.GOTESTSUM_ENABLED | default "true"}}'
+  GOTESTSUM_FORMAT: '{{.GOTESTSUM_FORMAT | default "testname"}}'
+  GOTESTSUM_VERSION: v1.13.0
   GO_SWAGGER: "{{.GOBIN}}/swagger"
   GO_SWAGGER_VERSION: v0.34.1
   OSV_SCANNER_VERSION: v2.4.0
@@ -334,6 +338,17 @@ tasks:
         if ! {{.GO_SWAGGER}} version | grep -q "{{.GO_SWAGGER_VERSION}}"; then
           echo "Installing go-swagger version {{.GO_SWAGGER_VERSION}}..."
           go install github.com/go-swagger/go-swagger/cmd/swagger@{{.GO_SWAGGER_VERSION}}
+        fi
+    silent: true
+  gotestsum-install:
+    cmds:
+      - |
+        if [ "{{.GOTESTSUM_ENABLED}}" != "true" ]; then
+          exit 0
+        fi
+        if ! {{.GOTESTSUM_BIN}} --version 2>/dev/null | grep -q "{{.GOTESTSUM_VERSION}}"; then
+          echo "Installing gotestsum version {{.GOTESTSUM_VERSION}}..."
+          go install gotest.tools/gotestsum@{{.GOTESTSUM_VERSION}}
         fi
     silent: true
   gta-install:
@@ -711,6 +726,7 @@ tasks:
   test:
     cmds:
       - task: golang-log
+      - task: gotestsum-install
       - |
         set -eu
 
@@ -730,7 +746,16 @@ tasks:
 
         # when "if testing.Short() { t.Skip() }" is in the go code then such
         # tests will be skipped if -short is used.
-        go test \
+        #
+        # gotestsum wraps 'go test' and reports the total number of tests that
+        # have been run, per testing type.
+        if [ "{{.GOTESTSUM_ENABLED}}" = "true" ]; then
+          set -- {{.GOTESTSUM_BIN}} --format {{.GOTESTSUM_FORMAT}} --
+        else
+          set -- go test
+        fi
+
+        "$@" \
           -p {{.GOLANG_PARALLEL_TESTS}} \
           -race \
           -short \

--- a/scripts/package-version-updater.sh
+++ b/scripts/package-version-updater.sh
@@ -55,6 +55,7 @@ readonly PACKAGES_TO_BE_UPDATED=(
   "GQLGEN_VERSION GQLGEN_VERSION gqlgen latest_stable_package_version_on_github 99designs/gqlgen"
   "GQLGENC_VERSION GQLGENC_VERSION gqlgenc latest_stable_package_version_on_github Yamashou/gqlgenc"
   "GRAPHQL_LINTER_VERSION GRAPHQL_LINTER_VERSION graphql-linter latest_stable_package_version_on_github schubergphilis/graphql-linter"
+  "GOTESTSUM_VERSION GOTESTSUM_VERSION gotestsum latest_stable_package_version_on_github gotestyourself/gotestsum"
   "MOCKERY_VERSION MOCKERY_VERSION mockery latest_stable_package_version_on_github vektra/mockery v3."
   "OPA_VERSION OPA_VERSION opa latest_stable_package_version_on_github open-policy-agent/opa"
   "OSV_SCANNER_VERSION OSV_SCANNER_VERSION osv-scanner latest_stable_package_version_on_github google/osv-scanner"


### PR DESCRIPTION
Closes #301.

## What

Runs all `test*` tasks through [gotestsum](https://github.com/gotestyourself/gotestsum) instead of plain `go test`, so every run ends with a summary line such as:

```
DONE 42 tests in 12.345s
```

Because each testing type (`unit`, `integration`, `component`, `e2e`) already runs as its own task/matrix job, this yields the per-type test counts asked for in #301.

## How

- `build/task.yml`
  - New vars: `GOTESTSUM_BIN`, `GOTESTSUM_ENABLED` (default `true`), `GOTESTSUM_FORMAT` (default `testname`), `GOTESTSUM_VERSION`.
  - New `gotestsum-install` task, following the existing `gta-install`/`osv-scanner-install` pattern. It is a no-op when `GOTESTSUM_ENABLED` is `false`.
  - The `test` task now picks `gotestsum --format <format> --` or `go test` and passes the existing flags unchanged.
- `scripts/package-version-updater.sh` - registers `GOTESTSUM_VERSION` so the weekly updater keeps it current.
- `README.md` / `CLAUDE.md` - document the new override variables.

## Opting out

```yml
includes:
  remote:
    taskfile: ...
    vars:
      GOTESTSUM_ENABLED: "false"
```

## Verified locally

- `task remote:test-cicd` on a scratch module: `DONE 3 tests in 1.374s`.
- Failing test still fails the task (exit code propagates through gotestsum).
- `task remote:coverage` unaffected; `-coverprofile` is passed through and the threshold check still works.
- `GOTESTSUM_ENABLED=false` falls back to the previous `go test` output.
- The `taskfile-sorted-units` and `taskfile-without-empty-lines` checks pass.

## Out of scope

Aggregating the four counts into a single cross-job summary (artifact upload + `$GITHUB_STEP_SUMMARY`) is deliberately left out; it can follow up if there is demand.