### PR TITLE
fix: pin upload-release-action to a commit sha

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -317,12 +317,19 @@ runs:
     #
     # Upload binaries to release
     #
+    # Pinned by commit SHA, like every other action referenced here. An
+    # organisation action policy can require full-length SHA pins, and it is
+    # applied to every action a composite action references, transitively:
+    # GitHub resolves them all during job setup, before any step's `if:` is
+    # evaluated. A tag ref here therefore failed consumers that never release a
+    # binary and never reach this step, as an unexplained `startup_failure` with
+    # no step logs. See issue #443.
     - name: Upload binaries to release
       if: |
         github.event_name == 'push' &&
         contains(github.ref, 'refs/tags/') &&
         inputs.release-dir != ''
-      uses: svenstaro/upload-release-action@2.11.5
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
       with:
         repo_token: ${{ inputs.token }}
         file: build/${{ inputs.release-type }}/${{ inputs.release-application-name }}/${{ inputs.release-architecture }}/main


### PR DESCRIPTION
Fixes the `startup_failure` reported in #443.

## The change

```diff
-      uses: svenstaro/upload-release-action@2.11.5
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
```

Plus a comment above the step recording why, so a future edit doesn't quietly go back to a tag.

## Why

This was the **only** non-SHA pin left in `action.yml` — `actions/setup-go` and `anchore/scan-action` were already pinned by commit — which is why it went unnoticed until an org policy started enforcing the rule.

An organisation can require every action to be pinned to a full-length commit SHA, and that requirement applies to every action a composite action references, **transitively**. GitHub resolves them all during job setup, *before* any step's `if:` is evaluated. So this reference broke consumers that never set `release-dir` and never reach the step — and it broke them as a `startup_failure` with no step logs at all, which is very hard to attribute to an upstream dependency.

Observed in `schubergphilis/item`: all five `mcvs-golang` matrix jobs (`lint`, `unit`, `integration`, `coverage`, `security-grype`) died in ~4s with:

```
##[error]The action svenstaro/upload-release-action@2.11.5 is not allowed in
schubergphilis/item because all actions must be from a repository owned by
schubergphilis, created by GitHub, or match one of the patterns: [...]
All actions must also be pinned to a full-length commit SHA.
```

Adding `svenstaro/upload-release-action@*` to that repo's allowlist was **not** sufficient on its own: the error persisted with the new pattern visibly present in the enumerated list, leaving the SHA rule as the only clause left to fail. Both halves are needed — the allowlist entry *and* this pin.

## Verification

- The `2.11.5` tag is **annotated**, so `git/ref/tags/2.11.5` returns a tag object (`ac75e1407b33421f1368f08e0e6cc567cc4edd25`). Pinning to that would not have been a commit SHA. The value used here is the dereferenced commit, `29e53e917877a24fad85510ded594ab3c9ca12de`, cross-checked against the tags list and confirmed to exist.
- Same commit the `2.11.5` tag points at, so **no behaviour change** — this is a re-spelling of the same reference, not a version bump.
- `actionlint`: no findings on `action.yml`.
- `yamllint` with `mcvs-general-action`'s own `configs/yamllint.yaml`: exit 0.
- Not exercised at runtime: reaching this step needs a tagged release with `release-dir` set, which this repo's own CI is the right place to prove.

## Note for consumers

Anyone on an allowlist still needs `svenstaro/upload-release-action@*` permitted, since a SHA-pinned reference must also match an allowed pattern. A `fix:` release would let affected repos pick this up by bumping.

## Alternative considered

Replacing the step with `gh release upload` removes the third-party dependency entirely and needs no allowlist entry, since `gh` is preinstalled on GitHub-hosted runners. Not proposed here: it would change behaviour for anyone releasing from a self-hosted runner without `gh`, where `upload-release-action` is self-contained. Happy to open that instead if maintainers prefer it.
