### PR TITLE
perf: enable go caching and install task from prebuilt binary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         inputs.testing-type == 'unit'
       with:
         go-version-file: ${{ inputs.go-version-file }}
-        cache: false
+        cache: true
     - name: install task
       if: |
         inputs.release-dir != '' ||
@@ -121,9 +121,23 @@ runs:
         inputs.testing-type == 'unit'
       shell: bash
       run: |
-        if ! task --version | grep -q "Task version: v${{ inputs.task-version }}"; then
-          major_version=$(echo "${{ inputs.task-version }}" | sed -E 's/^([0-9]+).*/\1/')
-          go install github.com/go-task/task/v${major_version}/cmd/task@v${{ inputs.task-version }}
+        # Task <= 3.38 reported 'Task version: v3.38.0 (h1:...)', whereas newer
+        # releases report a bare '3.51.1'. Matching the bare version covers
+        # both, so that an already installed Task is actually detected.
+        if ! task --version 2>/dev/null | grep -qF "${{ inputs.task-version }}"; then
+          # The prebuilt binary is used rather than 'go install', which compiles
+          # Task from source and costs roughly 90s in every job. This mirrors
+          # how golangci-lint is installed in build/task.yml.
+          #
+          # The destination mirrors what 'go install' would have used, so that
+          # Task still lands on a directory that is already on the PATH.
+          bindir="$(go env GOBIN)"
+          if [ -z "${bindir}" ]; then
+            bindir="$(go env GOPATH)/bin"
+          fi
+          curl \
+            -sSfL https://raw.githubusercontent.com/go-task/task/main/install-task.sh |\
+            sh -s -- -b "${bindir}" v${{ inputs.task-version }}
         fi
 
         echo "verifying that task can be found and run..."


### PR DESCRIPTION
## Problem

Two avoidable costs were being paid by **every job** in every repo using this action.

**1. `actions/setup-go` ran with `cache: false`**, so each job re-downloaded the full module graph and recompiled all dependencies from scratch. Measured on `mcvs-scanner` ([run 31747368897](https://github.com/schubergphilis/mcvs-scanner/actions/runs/31747368897)), time before the first test line appeared:

| job | cold compile |
|---|---|
| coverage | 297s |
| lint (e2e) | 223s |
| unit | 188s |

**2. The Task version guard has been dead since Task 3.44.** It matched `Task version: v<version>`, but the output format changed:

```
v3.38.0 -> 'Task version: v3.38.0 (h1:O7kgA6Bfwkt...)'
v3.44.0 -> '3.44.0'
v3.51.1 -> '3.51.1'
```

With `task-version` defaulting to `3.51.1`, the guard never matched, so every job unconditionally ran `go install github.com/go-task/task/...`, compiling Task from source. That cost **81-105s in each of the 10 matrix legs** on mcvs-scanner — roughly 16 minutes of runner time per push, to install a task runner that ships prebuilt binaries.

## Change

- `cache: false` -> `cache: true` on `actions/setup-go`.
- Guard now matches the bare version (`grep -qF "<version>"`), which covers both the old and new output formats, so an already-installed Task is actually detected.
- Install the prebuilt binary via `install-task.sh` instead of compiling from source, mirroring how `golangci-lint` is already installed in `build/task.yml`. The destination mirrors `go install` semantics (`$GOBIN`, falling back to `$(go env GOPATH)/bin`) so Task still lands on a directory already on the `PATH`.

## Why this is safe for coverage

The concern that motivated avoiding caching was #344 ("local lower coverage due to caching"). That was Go's **test result** cache, and it was fixed there by adding `-count=1` to the coverage task — still present at `build/task.yml:198`. `-count=1` forces test re-execution regardless of a warm build cache, so this change cannot reintroduce that failure mode.

## Verification

The new guard was tested in both directions:

| want | have | result |
|---|---|---|
| 3.51.1 | `3.51.1` | skips install |
| 3.51.1 | `Task version: v3.51.1 (h1:...)` | skips install |
| 3.51.1 | `3.44.0` | installs |
| 3.51.1 | (not installed) | installs |

The full install block was also run end-to-end: resolves bindir, installs v3.51.1 in ~2.6s (vs ~90s from source), and `task --version` reports `3.51.1`.

Draft, since this affects every repo consuming the action and deserves a look at CI timings on merge before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)