### PR TITLE
fix: bump golangci-lint to v2.13.0 for Go 1.27 support

### DIFF
--- a/build/task.yml
+++ b/build/task.yml
@@ -49,7 +49,7 @@ vars:
   COVERPROFILE: profile.cov
   COVERPROFILE_UNIQUE: "unique_{{.COVERPROFILE}}"
   GOLANGCI_LINT_CONFIG_PATH: '{{.GOLANGCI_LINT_CONFIG_PATH | default ".golangci.yml"}}'
-  GOLANGCI_LINT_VERSION: v2.12.2
+  GOLANGCI_LINT_VERSION: v2.13.0
   GOLANGCI_LINT_VERSION_WITHOUT_V_PREFIX: # the version found by the package-version-updater contains a 'v' prefix
     sh: echo {{.GOLANGCI_LINT_VERSION}} | sed -e "s|v||"
   GOLANGCI_LINT_RUN_TIMEOUT_MINUTES: "{{.GOLANGCI_LINT_RUN_TIMEOUT_MINUTES | default 3}}"


### PR DESCRIPTION
## Problem

Since v3.12.4 raised this action's own Go version to 1.27.0 (#449), every consumer whose `go.mod` targets Go 1.27 fails the `lint` testing-type immediately, at config load:

```
level=info msg="golangci-lint has version 2.12.2 built with go1.26.2 from c0d3ddc9 on 2026-05-06T11:07:58Z"
Error: can't load config: the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.0)
task: Failed to run task "remote:golangci-lint": task: Failed to run task "remote:golangci-lint-fmt": exit status 3
```

`GOLANGCI_LINT_VERSION` in `build/task.yml` is pinned to `v2.12.2`, which is built with go1.26.2. golangci-lint **v2.13.0** (released 2026-08-19) is built with go1.27.0 and its changelog carries `go1.27 support (#6642)`.

Consumers cannot work around this themselves: `GOLANGCI_LINT_VERSION` is a bare assignment rather than `{{.GOLANGCI_LINT_VERSION | default "..."}}`, so per go-task's include semantics the including Taskfile's `vars` cannot override it — unlike `GOLANGCI_LINT_CONFIG_PATH` one line above.

## Why CI didn't catch it

The self-test matrix in `.github/workflows/golang.yml` runs `opa`, `security-golang-modules` and `security-grype` — there is no `lint` testing-type, so golangci-lint never runs against this action's own Go version. #449 went green while breaking every downstream `lint` leg. Worth considering as a follow-up, separate from this fix.

## Verification

Using the released v2.13.0 binary (`golangci-lint has version 2.13.0 built with go1.27.0 from f838df1e on 2026-08-19T22:59:37Z`):

| Check | Result |
|---|---|
| `config verify` against this repo's `.golangci.yml` | pass |
| `config verify` against a consumer's `.golangci.yml` | pass (no schema migration needed) |
| `golangci-lint fmt` on a consumer with `go 1.27.0` | exit 0 (fails with v2.12.2) |
| `golangci-lint run --build-tags component --config .golangci.yml` on that consumer | exit 0, `0 issues.` |

Downstream failure this unblocks: schubergphilis/item#81.

